### PR TITLE
feat: add Spanish date format to DateFormats

### DIFF
--- a/docs/HELPERS.md
+++ b/docs/HELPERS.md
@@ -264,6 +264,7 @@ formats:
 - `DateFormats.SHORT`: 'MMM D, YYYY'
 - `DateFormats.LEGAL`: 'Do day of MMMM, YYYY'
 - `DateFormats.FORMAL`: 'dddd, MMMM Do, YYYY'
+- `DateFormats.SPANISH`: 'D de MMMMES de YYYY'
 
 **Examples:**
 
@@ -281,6 +282,10 @@ Legal format: {{formatDate(@today, "Do day of MMMM, YYYY")}}
 Formal format: {{formatDate(@today, "dddd, MMMM Do, YYYY")}}
 
 <!-- Output: Wednesday, July 16th, 2025 -->
+
+Spanish format: {{formatDate(@today, "D de MMMMES de YYYY")}}
+
+<!-- Output: 16 de julio de 2025 -->
 ```
 
 ## Number Helpers

--- a/src/helpers/date-helpers.ts
+++ b/src/helpers/date-helpers.ts
@@ -179,6 +179,7 @@ export function addMonths(date: Date | string, months: number): Date {
  * // Legal document formats
  * formatDate(date, DateFormats.LEGAL);   // "16th day of July, 2025"
  * formatDate(date, DateFormats.FORMAL);  // "Wednesday, July 16th, 2025"
+ * formatDate(date, DateFormats.SPANISH); // "16 de julio de 2025"
  *
  * // Custom format
  * formatDate(date, 'MMMM Do, YYYY');     // "July 16th, 2025"
@@ -228,6 +229,21 @@ export function formatDate(date: Date | string, format: string = 'YYYY-MM-DD'): 
     'Dec',
   ];
 
+  const monthNamesSpanish = [
+    'enero',
+    'febrero',
+    'marzo',
+    'abril',
+    'mayo',
+    'junio',
+    'julio',
+    'agosto',
+    'septiembre',
+    'octubre',
+    'noviembre',
+    'diciembre',
+  ];
+
   const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
   const dayNamesShort = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -241,6 +257,7 @@ export function formatDate(date: Date | string, format: string = 'YYYY-MM-DD'): 
     DD: day,
     D: String(d.getDate()),
     MMMM: monthNames[d.getMonth()],
+    MMMMES: monthNamesSpanish[d.getMonth()],
     MMM: monthNamesShort[d.getMonth()],
     dddd: dayNames[d.getDay()],
     ddd: dayNamesShort[d.getDay()],
@@ -276,6 +293,7 @@ export function formatDate(date: Date | string, format: string = 'YYYY-MM-DD'): 
   const orderedTokens = [
     'dddd',
     'ddd', // Day names (must come before DD/D)
+    'MMMMES', // Spanish month names (must come before MMMM)
     'MMMM',
     'MMM', // Month names (must come before MM/M)
     'YYYY',
@@ -340,6 +358,7 @@ function getOrdinalSuffix(n: number): string {
  * formatDate(date, DateFormats.FORMAL);  // "Wednesday, July 16th, 2025"
  * formatDate(date, DateFormats.US);      // "07/16/2025"
  * formatDate(date, DateFormats.EU);      // "16/07/2025"
+ * formatDate(date, DateFormats.SPANISH); // "16 de julio de 2025"
  * ```
  */
 export const DateFormats = {
@@ -352,6 +371,7 @@ export const DateFormats = {
   SHORT: 'MMM D, YYYY',
   LEGAL: 'Do day of MMMM, YYYY',
   FORMAL: 'dddd, MMMM Do, YYYY',
+  SPANISH: 'D de MMMMES de YYYY',
 } as const;
 
 /**

--- a/tests/unit/helpers/date-helpers.test.ts
+++ b/tests/unit/helpers/date-helpers.test.ts
@@ -91,6 +91,11 @@ describe('Date Helpers', () => {
       const result = formatDate(testDate, DateFormats.FULL);
       expect(result).toBe('January 15th, 2024');
     });
+
+    it('should format in Spanish', () => {
+      const result = formatDate(testDate, DateFormats.SPANISH);
+      expect(result).toBe('15 de enero de 2024');
+    });
   });
 
   describe('parseDate', () => {


### PR DESCRIPTION
## Summary

- Adds new `DateFormats.SPANISH` constant with pattern `'D de MMMMES de YYYY'`
- Implements Spanish month names support in `formatDate` function
- Adds comprehensive unit test coverage for Spanish format
- Updates documentation with Spanish format examples

## Changes Made

### Core Implementation
- **New Spanish month names array**: Added full Spanish month names (enero, febrero, marzo, etc.)
- **New format token `MMMMES`**: Dedicated token for Spanish month names to avoid conflicts
- **DateFormats.SPANISH constant**: Pattern `'D de MMMMES de YYYY'` producing "16 de julio de 2024"
- **Token processing order**: Updated to handle Spanish months before English months

### Testing
- **Unit test**: Verifies Spanish format produces correct output "15 de enero de 2024"
- **All existing tests pass**: No breaking changes to existing functionality

### Documentation
- **HELPERS.md updated**: Added Spanish format to predefined formats list
- **JSDoc examples**: Updated with Spanish format usage examples
- **Format examples**: Added output samples showing "16 de julio de 2025"

## Usage Example

```javascript
import { formatDate, DateFormats } from './date-helpers';

const date = new Date('2024-07-16');
const spanishDate = formatDate(date, DateFormats.SPANISH);
// Output: "16 de julio de 2024"

// Or using the pattern directly:
const customSpanish = formatDate(date, 'D de MMMMES de YYYY');
// Output: "16 de julio de 2024"
```

## Test Plan

- [x] Unit tests pass for Spanish format
- [x] All existing date format tests continue to pass  
- [x] Manual verification of Spanish month names
- [x] Documentation examples verified
- [x] TypeScript compilation successful

## Breaking Changes

None. This is a purely additive feature that doesn't modify existing behavior.

## Notes

The Spanish format follows the traditional Spanish date pattern "(día) de (mes) de (año)" which is commonly used in legal documents and formal communications in Spanish-speaking countries.