### PR TITLE
fix: resolve CSS paths relative to STYLES_DIR environment variable

### DIFF
--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -270,12 +270,19 @@ export class CliService {
     const resolvedInputPath = resolveFilePath(this.options.basePath, inputPath);
     const inputDir = path.dirname(resolvedInputPath);
 
+    // Resolve CSS path if provided
+    let cssPath = (options as any).cssPath || options.css;
+    if (cssPath && !path.isAbsolute(cssPath)) {
+      // If CSS path is relative, resolve it against STYLES_DIR
+      cssPath = path.resolve(RESOLVED_PATHS.STYLES_DIR, cssPath);
+    }
+
     // Use the passed options (already processed for force commands)
     const generateOptions = {
       ...options,
       basePath: inputDir,
       includeHighlighting: options.highlight,
-      cssPath: (options as any).cssPath || options.css,
+      cssPath,
       title: options.title || baseName,
     };
 


### PR DESCRIPTION
## Summary

- Fixes CSS path resolution when using relative paths with the `--css` option
- CSS files are now resolved against `STYLES_DIR` environment variable 
- Maintains backward compatibility with absolute paths

## Problem

When using the `--css` option with a relative path like `contract.petalo.css`, the CLI was looking for the file in the current working directory instead of resolving it relative to the configured `STYLES_DIR`.

This resulted in errors like:
```
[WARN] Failed to load CSS file: contract.petalo.css {
  error: Error: ENOENT: no such file or directory, open 'contract.petalo.css'
}
```

Even though the file existed in `src/styles/contract.petalo.css` and `STYLES_DIR=src/styles` was configured in `.env`.

## Solution

Modified `CliService` to detect relative CSS paths and resolve them against `RESOLVED_PATHS.STYLES_DIR`. The logic:

1. Check if the provided CSS path is relative using `path.isAbsolute()`
2. If relative, resolve it against `RESOLVED_PATHS.STYLES_DIR`  
3. If absolute, use the path as-is

## Changes

- **Modified**: `src/cli/service.ts`
  - Added CSS path resolution logic
  - Maintains compatibility with absolute paths
  - Uses existing `RESOLVED_PATHS.STYLES_DIR` constant

## Test plan

- [x] Test with relative CSS path: `--css contract.petalo.css`
- [x] Verify CSS loads from `src/styles/contract.petalo.css`
- [x] Test with absolute CSS path (backward compatibility)
- [x] Confirm CSS styles are applied in generated HTML
- [x] No warning messages about missing CSS files

## Usage Examples

**Before** (would fail):
```bash
npm run cli input.md output.html --css contract.petalo.css
# Error: ENOENT: no such file or directory
```

**After** (works correctly):
```bash
npm run cli input.md output.html --css contract.petalo.css
# Resolves to: src/styles/contract.petalo.css
```

**Absolute paths still work**:
```bash
npm run cli input.md output.html --css /full/path/to/custom.css
# Uses the absolute path as-is
```