### PR TITLE
style(playground): enhance with default CSS styles and improved markdown rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:ts": "tsc && tsc-alias",
     "build:styles": "mkdir -p dist/styles && cp -r $(node scripts/build-paths.js styles)/* dist/styles/ 2>/dev/null || true",
     "build:assets": "mkdir -p dist/assets && cp -r $(node scripts/build-paths.js images)/* dist/assets/ 2>/dev/null || true",
-    "build:web": "cp -r src/web dist/",
+    "build:web": "node scripts/build-web.js",
     "build:copy-umd": "cp dist/legal-markdown.umd.min.js dist/web/",
     "build:umd": "webpack --mode production --config webpack.config.js",
     "build:watch": "tsc --watch",

--- a/scripts/build-web.js
+++ b/scripts/build-web.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+/**
+ * Build script for web playground
+ * Automatically injects default CSS styles into the HTML file
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Escapes CSS content for safe inclusion in JavaScript template literals
+ */
+function escapeCSSForJS(css) {
+  return css
+    .replace(/\\/g, '\\\\')      // Escape backslashes
+    .replace(/`/g, '\\`')        // Escape backticks
+    .replace(/\${/g, '\\${');    // Escape template literal expressions
+}
+
+/**
+ * Main build function
+ */
+function buildWeb() {
+  try {
+    console.log('🏗️  Building web playground...');
+
+    // Define paths
+    const srcWebDir = path.join(process.cwd(), 'src/web');
+    const distWebDir = path.join(process.cwd(), 'dist/web');
+    const defaultCSSPath = path.join(process.cwd(), 'src/styles/default.css');
+    const htmlSourcePath = path.join(srcWebDir, 'index.html');
+    const htmlTargetPath = path.join(distWebDir, 'index.html');
+
+    // Ensure dist/web directory exists
+    if (!fs.existsSync(distWebDir)) {
+      fs.mkdirSync(distWebDir, { recursive: true });
+    }
+
+    // Read default CSS
+    console.log('📄 Reading default CSS...');
+    if (!fs.existsSync(defaultCSSPath)) {
+      throw new Error(`Default CSS file not found: ${defaultCSSPath}`);
+    }
+    
+    const defaultCSS = fs.readFileSync(defaultCSSPath, 'utf8');
+    const escapedCSS = escapeCSSForJS(defaultCSS);
+
+    // Read HTML template
+    console.log('📄 Reading HTML template...');
+    if (!fs.existsSync(htmlSourcePath)) {
+      throw new Error(`HTML source file not found: ${htmlSourcePath}`);
+    }
+    
+    let htmlContent = fs.readFileSync(htmlSourcePath, 'utf8');
+
+    // Inject the default CSS into the HTML
+    console.log('💉 Injecting default CSS...');
+    const defaultCSSInjection = `'default': \`/**
+ * Default Legal Markdown Styles
+ *
+ * Professional stylesheet for legal documents, optimized for both screen and print media.
+ * Features modern typography, clean design, and comprehensive print optimizations.
+ */
+
+${escapedCSS}\`,
+
+          `;
+
+    // Replace the placeholder with the actual CSS
+    htmlContent = htmlContent.replace(
+      '// DEFAULT_CSS_PLACEHOLDER - This will be replaced during build',
+      defaultCSSInjection
+    );
+
+    // Copy other files from src/web to dist/web (excluding index.html)
+    const srcFiles = fs.readdirSync(srcWebDir);
+    for (const file of srcFiles) {
+      if (file === 'index.html') continue; // Skip index.html, we handle it separately
+      
+      const srcFilePath = path.join(srcWebDir, file);
+      const distFilePath = path.join(distWebDir, file);
+      
+      if (fs.statSync(srcFilePath).isFile()) {
+        console.log(`📄 Copying ${file}...`);
+        fs.copyFileSync(srcFilePath, distFilePath);
+      }
+    }
+
+    // Write the processed HTML
+    console.log('💾 Writing processed HTML...');
+    fs.writeFileSync(htmlTargetPath, htmlContent, 'utf8');
+
+    console.log('✅ Web playground build completed successfully!');
+    console.log(`   → HTML: ${htmlTargetPath}`);
+    console.log(`   → Default CSS injected: ${Math.round(defaultCSS.length / 1024)}KB`);
+
+  } catch (error) {
+    console.error('❌ Web build failed:', error.message);
+    process.exit(1);
+  }
+}
+
+// Run the build if this script is executed directly
+if (require.main === module) {
+  buildWeb();
+}
+
+module.exports = { buildWeb };

--- a/scripts/build-web.js
+++ b/scripts/build-web.js
@@ -9,7 +9,15 @@ const fs = require('fs');
 const path = require('path');
 
 /**
- * Escapes CSS content for safe inclusion in JavaScript template literals
+ * Escapes CSS content for safe inclusion in JavaScript template literals.
+ * 
+ * @param {string} css - The CSS content to escape.
+ * @returns {string} - The escaped CSS content.
+ * 
+ * Example:
+ *   Input: "body { background: url('image.png'); }"
+ *   Output: "body { background: url('image.png'); }"
+ *           (with backslashes added where necessary for safe inclusion in template literals)
  */
 function escapeCSSForJS(css) {
   return css

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -72,6 +72,7 @@ Your content with {{variable}} substitutions..."></textarea>
             <div class="example-dropdown">
               <select class="css-example-select">
                 <option value="">🎨 CSS Examples</option>
+                <option value="default">Default Legal Styles</option>
                 <option value="modern">Modern Style</option>
                 <option value="classic">Classic Legal</option>
                 <option value="minimal">Minimal</option>
@@ -176,7 +177,7 @@ p {
                 </span>
               </label>
               <label class="checkbox-item">
-                <input type="checkbox" id="enableFieldTracking"> Field tracking
+                <input type="checkbox" id="enableFieldTracking" checked> Field tracking
                 <span class="tooltip">
                   <span class="tooltip-icon">ℹ️</span>
                   <span class="tooltip-text">Adds HTML spans around template variables and headers for debugging and styling. When disabled, maintains compatibility with Ruby version.</span>
@@ -273,6 +274,7 @@ p {
     <div id="messageArea"></div>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="./legal-markdown.umd.min.js"></script>
   <script>
     class LegalMarkdownApp {
@@ -288,6 +290,7 @@ p {
         this.initializePreviewResizer();
         this.updateBaseStyles(); // Initialize base styles
         this.loadExample('service-agreement');
+        this.loadCSSExample('default'); // Load default CSS by default
       }
 
       initializeTheme() {
@@ -485,18 +488,21 @@ p {
       }
 
       formatMarkdownForDisplay(content) {
-        // Basic markdown to HTML conversion for display
-        return content
-          .replace(/^# (.*$)/gm, '<h1>$1</h1>')
-          .replace(/^## (.*$)/gm, '<h2>$1</h2>')
-          .replace(/^### (.*$)/gm, '<h3>$1</h3>')
-          .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-          .replace(/\*(.*?)\*/g, '<em>$1</em>')
-          .replace(/\n\n/g, '</p><p>')
-          .replace(/^(.+)$/gm, '<p>$1</p>')
-          .replace(/<p><\/p>/g, '')
-          .replace(/<p>(<h[1-6]>.*<\/h[1-6]>)<\/p>/g, '$1');
+        // IMPORTANT: This content has already been processed by our Legal Markdown pipeline
+        // in processContent(). Here we just need to convert the final markdown to HTML.
+        try {
+          return marked.parse(content, {
+            breaks: true,
+            gfm: true
+          });
+        } catch (error) {
+          console.error('Marked library failed to load from CDN:', error);
+          return `<p>Error: Markdown parser unavailable. Please check your internet connection.</p>
+                  <pre>${this.escapeHtml(content)}</pre>`;
+        }
       }
+
+
 
       downloadDocument() {
         if (!this.processedResult) {
@@ -1357,7 +1363,7 @@ Signature: ___________________________ Date: ___________`
           stats.push(`${yamlKeys} YAML variables`);
         }
 
-        if (result.fieldReport) {
+        if (result.fieldReport && Array.isArray(result.fieldReport)) {
           stats.push(`${result.fieldReport.length} field substitutions`);
         }
 
@@ -1585,6 +1591,7 @@ Your content with {{variable}} substitutions...
 
       getCSSExamples() {
         return {
+          // DEFAULT_CSS_PLACEHOLDER - This will be replaced during build
           'modern': `/* Modern Clean Style */
 .preview-container {
   font-family: 'Segoe UI', system-ui, sans-serif;

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -274,7 +274,7 @@ p {
     <div id="messageArea"></div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked@16.1.1/marked.min.js"></script>
   <script src="./legal-markdown.umd.min.js"></script>
   <script>
     class LegalMarkdownApp {
@@ -490,14 +490,20 @@ p {
       formatMarkdownForDisplay(content) {
         // IMPORTANT: This content has already been processed by our Legal Markdown pipeline
         // in processContent(). Here we just need to convert the final markdown to HTML.
+        if (typeof marked === 'undefined') {
+          console.error('Marked library is not available. Ensure it is loaded correctly.');
+          return `<p>Error: Markdown parser unavailable. Please check your setup.</p>
+                  <pre>${this.escapeHtml(content)}</pre>`;
+        }
+
         try {
           return marked.parse(content, {
             breaks: true,
             gfm: true
           });
         } catch (error) {
-          console.error('Marked library failed to load from CDN:', error);
-          return `<p>Error: Markdown parser unavailable. Please check your internet connection.</p>
+          console.error('Markdown parsing failed:', error);
+          return `<p>Error: Failed to process Markdown content.</p>
                   <pre>${this.escapeHtml(content)}</pre>`;
         }
       }


### PR DESCRIPTION
## Summary
- Add automated CSS injection system for playground
- Include default.css styles as selectable option
- Enable field tracking by default for better UX
- Integrate marked.js from CDN for reliable markdown parsing
- Fix undefined field substitutions bug in statistics

## Changes Made
- ✅ **Automated CSS injection**: Created `scripts/build-web.js` to inject `default.css` into playground automatically
- ✅ **Default styles option**: Added "Default Legal Styles" to CSS examples dropdown
- ✅ **Field tracking enabled**: Checkbox now checked by default for immediate variable highlighting
- ✅ **Standard markdown parser**: Integrated marked.js from CDN for robust `_italic_` and `__bold__` rendering
- ✅ **Bug fix**: Fixed "undefined field substitutions" in processing statistics
- ✅ **Clean architecture**: Eliminated hardcoded parsers, using proper pipeline + standard tools

## Technical Details
The playground now follows a clean separation of concerns:
1. **Legal Markdown Pipeline**: Our library processes YAML, variables, mixins, clauses, references, headers
2. **Standard Markdown Parser**: marked.js converts final markdown to HTML
3. **Automated Styling**: Build system injects default.css without code duplication

## Test Plan
- [x] Default CSS styles load automatically
- [x] Field tracking highlights variables on first use
- [x] Markdown renders correctly (including `_italic_` → *italic*)
- [x] Processing statistics show proper counts
- [x] Build process works without manual intervention