### PR TITLE
fix: move dotenv from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "latex-ast-parser": "^1.1.0",
     "marked": "^15.0.12",
     "puppeteer": "^24.13.0",
-    "restructured": "^0.0.11"
+    "restructured": "^0.0.11",
+    "dotenv": "^17.2.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",
@@ -99,7 +100,6 @@
     "browserify": "^17.0.0",
     "commitizen": "^4.3.1",
     "cz-conventional-changelog": "^3.3.0",
-    "dotenv": "^17.2.1",
     "eslint": "^8.52.0",
     "glob": "^11.0.3",
     "husky": "^9.1.7",


### PR DESCRIPTION
Critical bug fix: dotenv is required at runtime but was in devDependencies, causing module not found errors for npm users.