### PR TITLE
fix: improve CLI console output formatting and eliminate duplicates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "legal-markdown-js",
-  "version": "2.6.4",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "legal-markdown-js",
-      "version": "2.6.4",
+      "version": "2.11.0",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.7.1",
@@ -14,6 +14,7 @@
         "chalk": "^4.1.2",
         "cheerio": "^1.1.0",
         "commander": "^11.1.0",
+        "dotenv": "^17.2.1",
         "js-beautify": "^1.15.4",
         "js-yaml": "^4.1.0",
         "latex-ast-parser": "^1.1.0",
@@ -23,6 +24,9 @@
       },
       "bin": {
         "legal-md": "dist/cli/index.js",
+        "legal-md-playground": "scripts/web-serve.js",
+        "legal-md-setup": "scripts/setup-config.js",
+        "legal-md-ui": "dist/cli/interactive/index.js",
         "legal2md": "dist/cli/index.js"
       },
       "devDependencies": {
@@ -41,7 +45,6 @@
         "browserify": "^17.0.0",
         "commitizen": "^4.3.1",
         "cz-conventional-changelog": "^3.3.0",
-        "dotenv": "^17.2.1",
         "eslint": "^8.52.0",
         "glob": "^11.0.3",
         "husky": "^9.1.7",
@@ -7023,7 +7026,6 @@
       "version": "17.2.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
       "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/src/cli/interactive/index.ts
+++ b/src/cli/interactive/index.ts
@@ -97,8 +97,6 @@ async function runInteractiveMode(): Promise<void> {
     }
 
     // Step 8: Process files
-    console.log(chalk.cyan('\n⏳ Processing files...\n'));
-
     const service = new InteractiveService(config);
     const result = await service.processFile(inputFile);
 

--- a/src/cli/interactive/service.ts
+++ b/src/cli/interactive/service.ts
@@ -112,12 +112,30 @@ export class InteractiveService {
         const pdfOutput = path.join(RESOLVED_PATHS.DEFAULT_OUTPUT_DIR, `${outputFilename}.pdf`);
         await nonArchivingService.processFile(inputFile, pdfOutput);
         outputFiles.push(pdfOutput);
+
+        // Add highlight version if highlight is enabled
+        if (processingOptions.highlight) {
+          const highlightPdfOutput = path.join(
+            RESOLVED_PATHS.DEFAULT_OUTPUT_DIR,
+            `${outputFilename}.HIGHLIGHT.pdf`
+          );
+          outputFiles.push(highlightPdfOutput);
+        }
       }
 
       if (outputFormats.html) {
         const htmlOutput = path.join(RESOLVED_PATHS.DEFAULT_OUTPUT_DIR, `${outputFilename}.html`);
         await nonArchivingService.processFile(inputFile, htmlOutput);
         outputFiles.push(htmlOutput);
+
+        // Add highlight version if highlight is enabled
+        if (processingOptions.highlight) {
+          const highlightHtmlOutput = path.join(
+            RESOLVED_PATHS.DEFAULT_OUTPUT_DIR,
+            `${outputFilename}.HIGHLIGHT.html`
+          );
+          outputFiles.push(highlightHtmlOutput);
+        }
       }
 
       if (outputFormats.markdown) {

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -308,19 +308,16 @@ export class CliService {
           includeHighlighting: false,
         });
         writeFileSync(htmlPath, normalHtmlContent);
-        this.log(`HTML output written to: ${htmlPath}`, 'success');
 
         // Highlighted version (with highlight CSS)
         const highlightHtmlContent = await generateHtml(content, {
           ...generateOptions,
           includeHighlighting: true,
         });
-        
-        writeFileSync(normalHtmlPath, normalHtmlContent);
-        writeFileSync(highlightedHtmlPath, highlightedHtmlContent);
 
-        generatedFiles.push(normalHtmlPath, highlightedHtmlPath);
+        writeFileSync(highlightHtmlPath, highlightHtmlContent);
 
+        generatedFiles.push(htmlPath, highlightHtmlPath);
       } else {
         // Generate single HTML without highlighting
         const htmlPath = path.join(dirName, `${baseName}.html`);
@@ -345,16 +342,19 @@ export class CliService {
           ...generateOptions,
           includeHighlighting: false,
         });
-        this.log(`PDF output written to: ${pdfPath}`, 'success');
 
-        generatedFiles.push(normalPdfPath, highlightedPdfPath);
+        // Highlighted version (with highlight CSS)
+        await generatePdf(content, highlightPdfPath, {
+          ...generateOptions,
+          includeHighlighting: true,
+        });
 
+        generatedFiles.push(pdfPath, highlightPdfPath);
       } else {
         // Generate single PDF without highlighting
         const pdfPath = path.join(dirName, `${baseName}.pdf`);
         await generatePdf(content, pdfPath, generateOptions);
         generatedFiles.push(pdfPath);
-
       }
     }
 

--- a/tests/unit/cli/interactive/service.test.ts
+++ b/tests/unit/cli/interactive/service.test.ts
@@ -163,7 +163,9 @@ describe('InteractiveService', () => {
       expect(result).toEqual({
         outputFiles: [
           '/test/output/processed-contract.pdf',
+          '/test/output/processed-contract.HIGHLIGHT.pdf',
           '/test/output/processed-contract.html',
+          '/test/output/processed-contract.HIGHLIGHT.html',
         ],
         archiveResult: undefined,
       });


### PR DESCRIPTION
## Summary
- Remove duplicate file processing messages in CLI service
- Add grouped file display when using --highlight flag  
- Show all generated files including markdown and highlight versions
- Remove unnecessary "Processing files..." message from interactive CLI
- Update tests to reflect new output file tracking behavior

## Changes Made
### Before
```
⏳ Processing files...

✅ HTML output written to: /path/file.html
✅ Highlighted HTML output written to: /path/file.HIGHLIGHT.html
✅ PDF output written to: /path/file.pdf
✅ Highlighted PDF output written to: /path/file.HIGHLIGHT.pdf
✅ HTML output written to: /path/file.html
✅ Highlighted HTML output written to: /path/file.HIGHLIGHT.html
✅ PDF output written to: /path/file.pdf
✅ Highlighted PDF output written to: /path/file.HIGHLIGHT.pdf

✅ Files generated successfully\!

📄 Generated files:
   /path/file.pdf
   /path/file.html
```

### After
**With --highlight flag:**
```
✅ Files generated successfully\!

📄 Generated files:

   HTML:
   /path/file.html
   /path/file.HIGHLIGHT.html

   PDF:
   /path/file.pdf
   /path/file.HIGHLIGHT.pdf
```

**Without --highlight flag:**
```
✅ Files generated successfully\!

📄 Generated files:
   /path/file.html
   /path/file.pdf
```

## Test plan
- [x] Test CLI with --highlight flag shows grouped output
- [x] Test CLI without --highlight flag shows simple list
- [x] Test interactive CLI uses same formatting
- [x] Test markdown-only output still works correctly
- [x] Verify all generated files are displayed (including highlight versions)
- [x] All existing tests pass