### PR TITLE
fix: use temp directories in interactive CLI tests

### DIFF
--- a/tests/integration/cli/interactive.test.ts
+++ b/tests/integration/cli/interactive.test.ts
@@ -2,28 +2,21 @@
  * @fileoverview Integration tests for Interactive CLI
  */
 
+import { expect, describe, it, beforeAll, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 import { spawn } from 'child_process';
-import { fileURLToPath } from 'url';
 import { CLI_PATHS } from '../../utils/cli-paths.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
 describe('Interactive CLI Integration', () => {
-  const testInputDir = path.join(__dirname, '../../../test-fixtures/interactive-input');
-  const testOutputDir = path.join(__dirname, '../../../test-fixtures/interactive-output');
+  const testInputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'legal-md-test-input-'));
+  const testOutputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'legal-md-test-output-'));
   const cliPath = CLI_PATHS.interactive;
   const activeProcesses: Set<any> = new Set();
 
   beforeAll(() => {
-    // Ensure test directories exist
-    if (!fs.existsSync(testInputDir)) {
-      fs.mkdirSync(testInputDir, { recursive: true });
-    }
-    if (!fs.existsSync(testOutputDir)) {
-      fs.mkdirSync(testOutputDir, { recursive: true });
-    }
+    // Test directories already created with mkdtempSync
 
     // Create test input file
     const testContent = `---
@@ -175,12 +168,7 @@ This is a test document for integration testing.`;
   }, 40000);
 
   it('should handle empty input directory gracefully', async () => {
-    const emptyDir = path.join(__dirname, '../../../test-fixtures/empty-interactive');
-    
-    // Create empty directory
-    if (!fs.existsSync(emptyDir)) {
-      fs.mkdirSync(emptyDir, { recursive: true });
-    }
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'legal-md-test-empty-'));
 
     const child = spawn('node', [cliPath], {
       stdio: ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION

- Replace hardcoded test-fixtures paths with os.tmpdir() temporary directories
- Use fs.mkdtempSync() for proper temporary directory creation and cleanup
- Add missing vitest imports (expect, describe, it, beforeAll, afterAll)
- Remove unused __dirname variable
- Prevents test artifacts from being created in project root directory

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🚀 Performance improvements
- [ ] ✅ Test improvements
- [ ] 🔧 Build/CI changes

## Testing

- [ ] Tests pass locally
- [ ] New tests added (for new features/bug fixes)
- [ ] Manual testing completed

## Checklist

- [ ] Code follows the project's coding standards
- [ ] Self-review of code completed
- [ ] Changes generate no new warnings
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if necessary)
- [ ] Conventional commit format used

## Related Issues

Closes #(issue_number)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information, context, or notes for reviewers -->
