### PR TITLE
fix: correctly handle empty string vs undefined in header level definitions

### DIFF
--- a/src/plugins/remark/headers.ts
+++ b/src/plugins/remark/headers.ts
@@ -164,16 +164,26 @@ export const remarkHeaders: Plugin<[RemarkHeadersOptions], Root> = options => {
  * Extract header configuration from document metadata
  */
 function extractHeaderConfig(metadata: Record<string, any>): HeaderConfig {
+  // Helper to get first defined value (including empty strings)
+  const getFirstDefined = (...keys: string[]): string | null => {
+    for (const key of keys) {
+      if (key in metadata) {
+        return metadata[key];
+      }
+    }
+    return null;
+  };
+
   return {
-    levelOne: metadata['level-1'] || metadata['level-one'] || metadata['level_one'] || null,
-    levelTwo: metadata['level-2'] || metadata['level-two'] || metadata['level_two'] || null,
-    levelThree: metadata['level-3'] || metadata['level-three'] || metadata['level_three'] || null,
-    levelFour: metadata['level-4'] || metadata['level-four'] || metadata['level_four'] || null,
-    levelFive: metadata['level-5'] || metadata['level-five'] || metadata['level_five'] || null,
-    levelSix: metadata['level-6'] || metadata['level-six'] || metadata['level_six'] || null,
-    levelSeven: metadata['level-7'] || metadata['level-seven'] || metadata['level_seven'] || null,
-    levelEight: metadata['level-8'] || metadata['level-eight'] || metadata['level_eight'] || null,
-    levelNine: metadata['level-9'] || metadata['level-nine'] || metadata['level_nine'] || null,
+    levelOne: getFirstDefined('level-1', 'level-one', 'level_one'),
+    levelTwo: getFirstDefined('level-2', 'level-two', 'level_two'),
+    levelThree: getFirstDefined('level-3', 'level-three', 'level_three'),
+    levelFour: getFirstDefined('level-4', 'level-four', 'level_four'),
+    levelFive: getFirstDefined('level-5', 'level-five', 'level_five'),
+    levelSix: getFirstDefined('level-6', 'level-six', 'level_six'),
+    levelSeven: getFirstDefined('level-7', 'level-seven', 'level_seven'),
+    levelEight: getFirstDefined('level-8', 'level-eight', 'level_eight'),
+    levelNine: getFirstDefined('level-9', 'level-nine', 'level_nine'),
     customFormats: new Map(),
   };
 }
@@ -279,7 +289,7 @@ function getHeaderFormat(level: number, config: HeaderConfig): string {
   }
 
   // If no format is defined, return undefined template
-  if (format === null) {
+  if (format === null || format === undefined) {
     return `{{undefined-level-${level}}}`;
   }
 

--- a/tests/unit/plugins/remark/headers-empty-string.test.ts
+++ b/tests/unit/plugins/remark/headers-empty-string.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @fileoverview Unit Tests for Headers Empty String Handling
+ *
+ * Tests for proper handling of empty string values in header level definitions.
+ * Empty strings should be treated as valid formats, not as undefined.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkStringify from 'remark-stringify';
+import { remarkHeaders, RemarkHeadersOptions } from '../../../../src/plugins/remark/headers';
+import { remarkLegalHeadersParser } from '../../../../src/plugins/remark/legal-headers-parser';
+
+/**
+ * Helper function to process markdown with headers plugin
+ */
+async function processMarkdownWithHeaders(
+  markdown: string,
+  options: RemarkHeadersOptions
+): Promise<string> {
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkLegalHeadersParser)
+    .use(remarkHeaders, options)
+    .use(remarkStringify, {
+      bullet: '-',
+      fences: true,
+      incrementListMarker: false,
+    });
+
+  const result = await processor.process(markdown);
+  return result.toString();
+}
+
+describe('Headers Empty String Handling', () => {
+  it('should treat empty string as valid format, not undefined', async () => {
+    const input = `l. First Level
+ll. Second Level
+lll. Third Level`;
+
+    const options: RemarkHeadersOptions = {
+      metadata: {
+        'level-1': 'Article %n.',
+        'level-2': '',  // Empty string - should be treated as valid
+        'level-3': 'Section %n.'
+      },
+      noIndent: true
+    };
+
+    const result = await processMarkdownWithHeaders(input, options);
+    
+    expect(result).toContain('# Article 1. First Level');
+    // Should NOT contain undefined-level-2, should just have empty prefix
+    expect(result).not.toContain('{{undefined-level-2}}');
+    expect(result).toContain('## &#x20;Second Level'); // Empty string becomes encoded space
+    expect(result).toContain('### Section 1. Third Level');
+  });
+
+  it('should distinguish between undefined and empty string', async () => {
+    const input = `l. One
+ll. Two
+lll. Three
+llll. Four`;
+
+    const options: RemarkHeadersOptions = {
+      metadata: {
+        'level-1': 'Chapter %n:',
+        'level-2': '',      // Empty string
+        // level-3 not defined (undefined)
+        'level-4': '   '    // Whitespace only
+      },
+      noIndent: true
+    };
+
+    const result = await processMarkdownWithHeaders(input, options);
+    
+    expect(result).toContain('# Chapter 1: One');
+    expect(result).toContain('## &#x20;Two');  // Empty string prefix becomes encoded space
+    expect(result).not.toContain('## {{undefined-level-2}}');
+    expect(result).toContain('### {{undefined-level-3}} Three');  // Undefined
+    expect(result).toContain('####     Four');  // Whitespace preserved
+  });
+
+  it('should handle empty string with numbering variables', async () => {
+    const input = `l. Main
+ll. Sub One
+ll. Sub Two`;
+
+    const options: RemarkHeadersOptions = {
+      metadata: {
+        'level-1': 'Part %n:',
+        'level-2': '%n. '  // Just the number and dot
+      },
+      noIndent: true
+    };
+
+    const result = await processMarkdownWithHeaders(input, options);
+    
+    expect(result).toContain('# Part 1: Main');
+    expect(result).toContain('## 1.  Sub One');  // Note the extra space after dot
+    expect(result).toContain('## 2.  Sub Two');
+  });
+
+  it('should handle all variations of empty values', async () => {
+    const input = `l. Test One
+ll. Test Two
+lll. Test Three
+llll. Test Four
+lllll. Test Five`;
+
+    const options: RemarkHeadersOptions = {
+      metadata: {
+        'level-1': '',         // Empty string
+        'level-2': null,       // Explicit null
+        'level-3': undefined,  // Explicit undefined
+        // level-4 not present (implicit undefined)
+        'level-5': '(%n)'      // Normal format
+      },
+      noIndent: true
+    };
+
+    const result = await processMarkdownWithHeaders(input, options);
+    
+    // Empty string - encoded space prefix
+    expect(result).toContain('# &#x20;Test One');
+    expect(result).not.toContain('# {{undefined-level-1}}');
+    
+    // Null - undefined template
+    expect(result).toContain('## {{undefined-level-2}} Test Two');
+    
+    // Explicit undefined - undefined template  
+    expect(result).toContain('### {{undefined-level-3}} Test Three');
+    
+    // Not present - undefined template
+    expect(result).toContain('#### {{undefined-level-4}} Test Four');
+    
+    // Normal format
+    expect(result).toContain('##### (1) Test Five');
+  });
+
+  it('should work with alternative key formats', async () => {
+    const input = `l. Header One
+ll. Header Two`;
+
+    const options: RemarkHeadersOptions = {
+      metadata: {
+        'level-one': '',      // Empty string with dash format
+        'level_two': ''       // Empty string with underscore format
+      },
+      noIndent: true
+    };
+
+    const result = await processMarkdownWithHeaders(input, options);
+    
+    expect(result).toContain('# &#x20;Header One');
+    expect(result).toContain('## &#x20;Header Two');
+    expect(result).not.toContain('{{undefined-level-');
+  });
+
+  it('should handle complex empty string scenarios', async () => {
+    const input = `l. Article
+ll. Section
+lll. Subsection with reference |key|`;
+
+    const options: RemarkHeadersOptions = {
+      metadata: {
+        'level-1': '%n. ',
+        'level-2': '',
+        'level-3': '- '
+      },
+      noIndent: true
+    };
+
+    const result = await processMarkdownWithHeaders(input, options);
+    
+    expect(result).toContain('# 1.  Article');  // Note extra space after dot
+    expect(result).toContain('## &#x20;Section');
+    expect(result).toContain('### -  Subsection with reference');
+  });
+});


### PR DESCRIPTION
## Summary

- Fix header level processing to correctly distinguish between empty string and undefined values
- Resolve issue where `level-six: ""` was incorrectly showing `{{undefined-level-6}}`
- Add comprehensive test coverage for empty string handling scenarios

## Problem

When defining header levels in YAML frontmatter:
- `level-six: null` or not defined → should show `{{undefined-level-6}}`  
- `level-six: ""` → should use empty string as valid format

Previously, both cases incorrectly showed `{{undefined-level-6}}` due to:
1. `extractHeaderConfig` using `||` operator which treats empty strings as falsy
2. `getHeaderFormat` only checking for `null`, not `undefined`

## Changes

### Fixed Logic
- **extractHeaderConfig**: Use `key in metadata` to distinguish undefined vs empty values
- **getHeaderFormat**: Check for both `null` and `undefined` format values

### Test Coverage
Added 6 comprehensive tests covering:
- Empty string vs undefined distinction
- Numbering variables with empty formats
- Alternative key formats (`level-one`, `level_one`)
- Complex scenarios with mixed empty/undefined levels
- Whitespace-only formats vs truly empty strings

## Test Results

All new tests pass, existing tests remain unaffected.

```
✓ Headers Empty String Handling > should treat empty string as valid format, not undefined
✓ Headers Empty String Handling > should distinguish between undefined and empty string  
✓ Headers Empty String Handling > should handle empty string with numbering variables
✓ Headers Empty String Handling > should handle all variations of empty values
✓ Headers Empty String Handling > should work with alternative key formats
✓ Headers Empty String Handling > should handle complex empty string scenarios
```