### PR TITLE
fix: prevent indented headers from becoming code blocks in HTML/PDF

### DIFF
--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -338,7 +338,7 @@ export class CliService {
       cssPath,
       highlightCssPath: path.join(process.cwd(), 'src/styles/highlight.css'),
       title: options.title || baseName,
-      // Force noIndent: true for HTML/PDF generation to prevent indented headers 
+      // Force noIndent: true for HTML/PDF generation to prevent indented headers
       // from being interpreted as code blocks by remark
       noIndent: true,
     };

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -338,6 +338,9 @@ export class CliService {
       cssPath,
       highlightCssPath: path.join(process.cwd(), 'src/styles/highlight.css'),
       title: options.title || baseName,
+      // Force noIndent: true for HTML/PDF generation to prevent indented headers 
+      // from being interpreted as code blocks by remark
+      noIndent: true,
     };
 
     const generatedFiles: string[] = [];

--- a/tests/integration/cli-html-no-indent.integration.test.ts
+++ b/tests/integration/cli-html-no-indent.integration.test.ts
@@ -1,0 +1,238 @@
+/**
+ * @fileoverview Integration Tests for CLI HTML Generation with No-Indent
+ *
+ * Tests that verify HTML generation correctly uses noIndent: true to prevent
+ * indented headers from being interpreted as code blocks by remark.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { spawn } from 'child_process';
+import { CLI_PATHS } from '../utils/cli-paths.js';
+
+describe('CLI HTML Generation No-Indent Integration', () => {
+  const testInputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'legal-md-html-test-input-'));
+  const testOutputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'legal-md-html-test-output-'));
+  const cliPath = CLI_PATHS.main;
+
+  beforeAll(() => {
+    // Create test document with multiple header levels
+    const testContent = `---
+title: Test Document for HTML Generation
+level-one: 'Article %n.'
+level-two: 'Section %n.'
+level-three: 'Subsection %n.'
+level-four: 'Point %n.'
+---
+
+l. First Article
+
+ll. First Section
+Content under first section.
+
+lll. Deep Subsection
+Content under subsection.
+
+llll. Even Deeper
+Content under point.
+
+ll. Second Section
+More content.
+
+l. Second Article
+Final content.`;
+
+    fs.writeFileSync(path.join(testInputDir, 'test-headers.md'), testContent);
+  });
+
+  afterAll(() => {
+    // Clean up test files
+    try {
+      fs.rmSync(testInputDir, { recursive: true, force: true });
+      fs.rmSync(testOutputDir, { recursive: true, force: true });
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('should generate HTML without code blocks for indented headers', async () => {
+    return new Promise((resolve, reject) => {
+      const child = spawn('node', [cliPath, 'test-headers.md', '--html'], {
+        cwd: __dirname,
+        env: {
+          ...process.env,
+          DEFAULT_INPUT_DIR: testInputDir,
+          DEFAULT_OUTPUT_DIR: testOutputDir,
+        },
+        stdio: ['pipe', 'pipe', 'pipe']
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      child.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      child.on('close', (code) => {
+        try {
+          if (code !== 0) {
+            reject(new Error(`CLI process failed with code ${code}. Stderr: ${stderr}`));
+            return;
+          }
+
+          expect(stdout).toContain('Files generated successfully!');
+
+          // Check that HTML file was generated
+          const htmlPath = path.join(testOutputDir, 'test-headers.html');
+          expect(fs.existsSync(htmlPath)).toBe(true);
+
+          // Read the generated HTML
+          const htmlContent = fs.readFileSync(htmlPath, 'utf-8');
+
+          // Verify headers are properly formatted (not in code blocks)
+          expect(htmlContent).toContain('Article 1. First Article');
+          expect(htmlContent).toContain('Section 1. First Section');
+          expect(htmlContent).toContain('Subsection 1. Deep Subsection');
+          expect(htmlContent).toContain('Point 1. Even Deeper');
+
+          // Verify headers have proper CSS classes (indicating field tracking worked)
+          expect(htmlContent).toContain('class="legal-header legal-header-level-1 legal-article"');
+          expect(htmlContent).toContain('class="legal-header legal-header-level-2 legal-section"');
+          expect(htmlContent).toContain('class="legal-header legal-header-level-3 legal-subsection"');
+          expect(htmlContent).toContain('class="legal-header legal-header-level-4 legal-sub-subsection"');
+
+          // Verify headers are wrapped in spans, not in code blocks
+          expect(htmlContent).toContain('<span class="legal-header');
+          expect(htmlContent).not.toContain('<pre><code>  <span class="legal-header');
+
+          // Verify data attributes are present
+          expect(htmlContent).toContain('data-level="1"');
+          expect(htmlContent).toContain('data-level="2"');
+          expect(htmlContent).toContain('data-level="3"');
+          expect(htmlContent).toContain('data-level="4"');
+
+          resolve(void 0);
+        } catch (error) {
+          reject(error);
+        }
+      });
+
+      child.on('error', (error) => {
+        reject(error);
+      });
+    });
+  }, 30000);
+
+  it('should generate PDF without issues using same pipeline', async () => {
+    return new Promise((resolve, reject) => {
+      const child = spawn('node', [cliPath, 'test-headers.md', '--pdf'], {
+        cwd: __dirname,
+        env: {
+          ...process.env,
+          DEFAULT_INPUT_DIR: testInputDir,
+          DEFAULT_OUTPUT_DIR: testOutputDir,
+        },
+        stdio: ['pipe', 'pipe', 'pipe']
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      child.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      child.on('close', (code) => {
+        try {
+          if (code !== 0) {
+            reject(new Error(`CLI process failed with code ${code}. Stderr: ${stderr}`));
+            return;
+          }
+
+          expect(stdout).toContain('Files generated successfully!');
+
+          // Check that PDF file was generated
+          const pdfPath = path.join(testOutputDir, 'test-headers.pdf');
+          expect(fs.existsSync(pdfPath)).toBe(true);
+
+          // Basic check that the PDF file has some content
+          const pdfStats = fs.statSync(pdfPath);
+          expect(pdfStats.size).toBeGreaterThan(1000); // PDF should be at least 1KB
+
+          resolve(void 0);
+        } catch (error) {
+          reject(error);
+        }
+      });
+
+      child.on('error', (error) => {
+        reject(error);
+      });
+    });
+  }, 30000);
+
+  it('should still preserve indentation in markdown output when --to-markdown is used', async () => {
+    return new Promise((resolve, reject) => {
+      const child = spawn('node', [cliPath, 'test-headers.md', '--to-markdown'], {
+        cwd: __dirname,
+        env: {
+          ...process.env,
+          DEFAULT_INPUT_DIR: testInputDir,
+          DEFAULT_OUTPUT_DIR: testOutputDir,
+        },
+        stdio: ['pipe', 'pipe', 'pipe']
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      child.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      child.on('close', (code) => {
+        try {
+          if (code !== 0) {
+            reject(new Error(`CLI process failed with code ${code}. Stderr: ${stderr}`));
+            return;
+          }
+
+          // For --to-markdown, content may be sent to stdout directly
+          // so we check for either success message or markdown content
+          const hasSuccessMessage = stdout.includes('Files generated successfully!');
+          const hasMarkdownContent = stdout.includes('Article 1. First Article');
+          expect(hasSuccessMessage || hasMarkdownContent).toBe(true);
+
+          // Verify markdown output preserves indentation for readability
+          // This is tested by checking that deeper levels have indentation in stdout
+          expect(stdout).toContain('Article 1. First Article');
+          expect(stdout).toMatch(/\s+Section 1\. First Section/); // Should have indentation
+          expect(stdout).toMatch(/\s+Subsection 1\. Deep Subsection/); // Should have more indentation
+
+          resolve(void 0);
+        } catch (error) {
+          reject(error);
+        }
+      });
+
+      child.on('error', (error) => {
+        reject(error);
+      });
+    });
+  }, 30000);
+});


### PR DESCRIPTION
## Summary

- Fix HTML/PDF generation pipeline to prevent indented headers from being interpreted as code blocks
- Force `noIndent: true` in HTML/PDF generation to maintain clean header structure
- Add comprehensive integration tests to verify the fix works correctly

## Problem

When generating HTML or PDF output, headers at level 3 and deeper were being indented by the header processor. This caused remark to interpret them as code blocks, resulting in malformed HTML:

```html
<\!-- BEFORE (broken) -->
<pre><code>  <span class="legal-header legal-header-level-3 legal-subsection" data-level="3" data-number="2">Sección 2 - Pago de los servicios</span></code></pre>

<\!-- AFTER (fixed) -->
<span class="legal-header legal-header-level-3 legal-subsection" data-level="3" data-number="2">Sección 2 - Pago de los servicios</span>
```

## Root Cause

The CLI service was processing content for HTML/PDF generation with the default header indentation settings. When the intermediate markdown contained indented headers (like `  Subsection 1.`), remark interpreted the leading spaces as indicating a code block.

## Solution

### 1. Force `noIndent: true` for HTML/PDF Generation
Updated `generateFormattedOutputWithOptions` in CLI service to force `noIndent: true` when generating HTML/PDF output:

```typescript
const generateOptions = {
  ...options,
  // ... other options
  // Force noIndent: true for HTML/PDF generation to prevent indented headers 
  // from being interpreted as code blocks by remark
  noIndent: true,
};
```

### 2. Preserve Indentation for Markdown Output
The fix only affects HTML/PDF generation. Markdown output (`--to-markdown`) still preserves indentation for readability.

### 3. Comprehensive Testing
Added integration tests that verify:
- HTML generation produces proper `<span>` elements with CSS classes
- Headers are NOT wrapped in `<pre><code>` blocks
- PDF generation works correctly (uses same pipeline)
- Field tracking and CSS classes are maintained
- Markdown output still preserves indentation when needed

## Test Results

All tests pass:
- ✅ HTML generation produces clean header spans
- ✅ PDF generation works without issues
- ✅ Field tracking and CSS classes are preserved
- ✅ No code blocks around headers
- ✅ Markdown output maintains indentation

## Files Changed

- `src/cli/service.ts` - Force `noIndent: true` for HTML/PDF generation
- `tests/integration/cli-html-no-indent.integration.test.ts` - Comprehensive test coverage

## Verification

The fix has been tested with real documents and produces clean HTML output where headers maintain their semantic structure and styling capabilities.