### PR TITLE
Fix: Show relative paths in interactive file selector for cleaner UI

### DIFF
--- a/src/cli/interactive/prompts/file-selector.ts
+++ b/src/cli/interactive/prompts/file-selector.ts
@@ -168,7 +168,7 @@ export async function selectInputFile(): Promise<string> {
 
     // Continue with defaults - scan current directory instead
     console.log(chalk.cyan('\n🔍 Using current directory as input...\n'));
-    const currentDirFiles = scanDirectory(process.cwd());
+    const currentDirFiles = scanDirectory(process.cwd(), process.cwd());
 
     if (currentDirFiles.length === 0) {
       console.log(formatWarningMessage('No supported files found in current directory.'));
@@ -197,7 +197,7 @@ export async function selectInputFile(): Promise<string> {
   // Configuration is valid - use configured directory
   console.log(chalk.cyan(`🔍 Searching for files in: ${RESOLVED_PATHS.DEFAULT_INPUT_DIR}\n`));
 
-  const files = scanDirectory(RESOLVED_PATHS.DEFAULT_INPUT_DIR);
+  const files = scanDirectory(RESOLVED_PATHS.DEFAULT_INPUT_DIR, RESOLVED_PATHS.DEFAULT_INPUT_DIR);
 
   if (files.length === 0) {
     console.log(formatWarningMessage('No supported files found in the configured directory.'));

--- a/src/cli/interactive/prompts/ftux-handler.ts
+++ b/src/cli/interactive/prompts/ftux-handler.ts
@@ -226,7 +226,8 @@ ARCHIVE_DIR="${path.resolve(archiveDir)}"
 
   // Now scan for files in the configured input directory
   console.log(chalk.cyan(`\n🔍 Scanning for files in: ${path.resolve(inputDir)}\n`));
-  const files = scanDirectory(path.resolve(inputDir));
+  const resolvedInputDir = path.resolve(inputDir);
+  const files = scanDirectory(resolvedInputDir, resolvedInputDir);
 
   if (files.length === 0) {
     console.log(formatWarningMessage('No supported files found in the configured directory.'));

--- a/src/cli/interactive/utils/file-input-helpers.ts
+++ b/src/cli/interactive/utils/file-input-helpers.ts
@@ -47,7 +47,7 @@ export async function handleBrowseFolder(): Promise<string> {
   const resolvedPath = path.resolve(folderPath);
   console.log(chalk.cyan(`🔍 Searching for files in: ${resolvedPath}\\n`));
 
-  const files = scanDirectory(resolvedPath);
+  const files = scanDirectory(resolvedPath, resolvedPath);
 
   if (files.length === 0) {
     console.log(formatWarningMessage('No supported files found in this directory.'));

--- a/src/cli/interactive/utils/file-scanner.ts
+++ b/src/cli/interactive/utils/file-scanner.ts
@@ -26,10 +26,12 @@ const SUPPORTED_EXTENSIONS = ['.md', '.markdown', '.rst', '.tex', '.latex', '.tx
  * suitable for interactive selection menus.
  *
  * @param dirPath Absolute path to the directory to scan
+ * @param baseDir Optional base directory for calculating relative paths. If not provided, uses process.cwd()
  * @returns Array of FileItem objects representing discovered files and directories
  */
-export function scanDirectory(dirPath: string): FileItem[] {
+export function scanDirectory(dirPath: string, baseDir?: string): FileItem[] {
   const items: FileItem[] = [];
+  const relativeTo = baseDir || process.cwd();
 
   try {
     if (!fs.existsSync(dirPath)) {
@@ -43,13 +45,13 @@ export function scanDirectory(dirPath: string): FileItem[] {
 
       if (entry.isDirectory()) {
         // Add subdirectory files recursively
-        const subItems = scanDirectory(fullPath);
+        const subItems = scanDirectory(fullPath, baseDir);
         items.push(...subItems);
       } else if (entry.isFile()) {
         const ext = path.extname(entry.name).toLowerCase();
         if (SUPPORTED_EXTENSIONS.includes(ext)) {
           items.push({
-            name: path.relative(process.cwd(), fullPath),
+            name: path.relative(relativeTo, fullPath),
             path: fullPath,
             type: 'file',
           });


### PR DESCRIPTION
## Summary
- Add optional `baseDir` parameter to `scanDirectory()` function for calculating relative paths
- Update interactive file selector to show relative paths based on configured input directory
- Maintain backward compatibility with existing code

## Problem Solved
When using interactive mode with directories outside the current working directory, the file selector showed verbose absolute paths like `/Users/username/Documents/project/subfolder/document.md` instead of clean relative paths.

## Changes Made
1. **Enhanced `scanDirectory()` function** in `file-scanner.ts`:
   - Added optional `baseDir` parameter
   - Uses `path.relative(baseDir, fullPath)` instead of hardcoded `process.cwd()`
   - Maintains backward compatibility by defaulting to `process.cwd()`

2. **Updated file selector calls** to pass appropriate base directories:
   - `file-selector.ts`: Pass `RESOLVED_PATHS.DEFAULT_INPUT_DIR` when scanning configured directory
   - `ftux-handler.ts`: Use resolved input directory as base for relative paths  
   - `file-input-helpers.ts`: Use browsed directory as base when navigating

## Test plan
- [x] All unit tests pass
- [x] Backward compatibility maintained - existing code without baseDir works unchanged
- [x] Interactive file selector shows clean relative paths
- [x] FTUX flow shows relative paths when setting up directories
- [x] Manual folder browsing shows relative paths to selected directory

## Before/After
**Before:** `/Users/diego/Documents/legal-docs/contracts/service-agreement.md`  
**After:** `contracts/service-agreement.md`

This creates a much cleaner and more user-friendly experience in interactive mode.