### PR TITLE
Add signature lines detection and styling

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -14,6 +14,8 @@ This section contains detailed documentation for all Legal Markdown JS features.
 - [Partial Imports](partial-imports.md) - File inclusion and frontmatter merging
 - [Variables & Mixins](mixins-variables.md) - Template variable substitution
 - [Template Loops](template-loops.md) - Array iteration and conditional blocks
+- [Signature Lines](signature-lines.md) - Automatic detection and styling of
+  signature lines
 - [Force Commands](force-commands.md) - Self-configuring documents
 - [Smart Archiving](smart-archiving.md) - Intelligent file management
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -14,7 +14,7 @@ This section contains detailed documentation for all Legal Markdown JS features.
 - [Partial Imports](partial-imports.md) - File inclusion and frontmatter merging
 - [Variables & Mixins](mixins-variables.md) - Template variable substitution
 - [Template Loops](template-loops.md) - Array iteration and conditional blocks
-- [Signature Lines](signature-lines.md) - Automatic detection and styling of
+- [Signature Lines](signature-lines.md) - Automatic detection and CSS styling of
   signature lines
 - [Force Commands](force-commands.md) - Self-configuring documents
 - [Smart Archiving](smart-archiving.md) - Intelligent file management

--- a/docs/features/signature-lines.md
+++ b/docs/features/signature-lines.md
@@ -1,0 +1,480 @@
+# Signature Lines
+
+Signature lines are automatically detected and wrapped with CSS classes for
+styling. This feature identifies long sequences of underscores (typically used
+to indicate where signatures should be placed) and adds HTML markup for
+consistent styling.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Basic Usage](#basic-usage)
+- [Configuration](#configuration)
+- [CSS Styling](#css-styling)
+- [Examples](#examples)
+- [Best Practices](#best-practices)
+
+## Overview
+
+Legal Markdown automatically detects sequences of 10 or more consecutive
+underscores and wraps them with a `<span class="signature-line">` element. This
+allows you to style signature lines consistently across your documents using
+CSS.
+
+**Input:**
+
+```markdown
+Signature: ************\_\_************
+```
+
+**Output:**
+
+```markdown
+Signature: <span class="signature-line">************\_\_************</span>
+```
+
+## Basic Usage
+
+### Simple Signature Line
+
+```markdown
+**Client Representative**
+
+Signature: ************\_\_************
+
+Date: ********\_\_\_\_********
+```
+
+The longer underscore sequence (26 underscores) and shorter one (20 underscores)
+are both detected and wrapped with CSS classes.
+
+### Multiple Signature Lines
+
+```markdown
+**Party A**
+
+Signature: ************\_\_************ Date: ****\_\_****
+
+**Party B**
+
+Signature: ************\_\_************ Date: ****\_\_****
+```
+
+All signature lines in the document are automatically detected and styled.
+
+### Signature Blocks
+
+```markdown
+## SIGNATURES
+
+---
+
+**Client Representative**
+
+Name: ************\_\_************
+
+Signature: ************\_\_************
+
+Date: ********\_\_\_\_********
+
+**Service Provider**
+
+Name: ************\_\_************
+
+Signature: ************\_\_************
+
+Date: ********\_\_\_\_********
+```
+
+## Configuration
+
+The signature line detection behavior can be customized through the remark
+plugin options:
+
+### Minimum Underscores
+
+By default, sequences of 10 or more underscores are treated as signature lines.
+You can adjust this threshold:
+
+```typescript
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkSignatureLines from '@legal-markdown/signature-lines';
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkSignatureLines, { minUnderscores: 15 })
+  .use(remarkStringify);
+```
+
+### Custom CSS Class
+
+Change the CSS class applied to signature lines:
+
+```typescript
+.use(remarkSignatureLines, {
+  cssClassName: 'document-signature-line'
+})
+```
+
+### Disable CSS Wrapping
+
+Process signature lines without adding CSS classes:
+
+```typescript
+.use(remarkSignatureLines, {
+  addCssClass: false
+})
+```
+
+## CSS Styling
+
+### Default Styles
+
+Add these styles to your CSS to customize signature line appearance:
+
+```css
+.signature-line {
+  display: inline-block;
+  border-bottom: 1px solid #000;
+  min-width: 200px;
+}
+```
+
+### Print-Optimized Styles
+
+Ensure signature lines appear correctly in printed documents:
+
+```css
+@media print {
+  .signature-line {
+    border-bottom: 1px solid #000;
+    min-width: 3in; /* Minimum 3 inches for signatures */
+  }
+}
+```
+
+### Styled Example
+
+```css
+.signature-line {
+  display: inline-block;
+  border-bottom: 2px solid #333;
+  min-width: 250px;
+  padding: 0 5px;
+  margin: 0 10px;
+  position: relative;
+  bottom: -2px;
+}
+
+/* Remove underscores visually, keeping them for structure */
+.signature-line {
+  font-size: 0;
+  line-height: 0;
+}
+```
+
+### Accessibility Styles
+
+Add aria labels for screen readers:
+
+```html
+<span class="signature-line" aria-label="Signature line"
+  >__________________________</span
+>
+```
+
+## Examples
+
+### Contract Signature Block
+
+```markdown
+# SERVICE AGREEMENT
+
+This agreement is entered into on {{contract_date}}.
+
+## SIGNATURES
+
+The parties have executed this agreement as of the date first written above.
+
+**CLIENT**
+
+Name: ************\_\_************
+
+Signature: ************\_\_************
+
+Date: ********\_\_\_\_********
+
+**SERVICE PROVIDER**
+
+Name: ************\_\_************
+
+Signature: ************\_\_************
+
+Date: ********\_\_\_\_********
+```
+
+### Witness Section
+
+```markdown
+## WITNESSES
+
+The undersigned witnesses have witnessed the execution of this document.
+
+**Witness 1**
+
+Signature: ************\_\_************ Date: ****\_\_****
+
+Print Name: ************\_\_************
+
+**Witness 2**
+
+Signature: ************\_\_************ Date: ****\_\_****
+
+Print Name: ************\_\_************
+```
+
+### Notary Block
+
+```markdown
+## NOTARY ACKNOWLEDGMENT
+
+**Notary Public**
+
+Signature: ************\_\_************
+
+Print Name: ************\_\_************
+
+My Commission Expires: ********\_\_\_\_********
+
+Notary Seal: ************\_\_************
+```
+
+### Table Format
+
+```markdown
+| Party   | Signature                    | Date         |
+| ------- | ---------------------------- | ------------ |
+| Party A | ************\_\_************ | ****\_\_**** |
+| Party B | ************\_\_************ | ****\_\_**** |
+| Witness | ************\_\_************ | ****\_\_**** |
+```
+
+## Best Practices
+
+### 1. Use Consistent Lengths
+
+Use consistent underscore lengths for signature lines throughout your document:
+
+```markdown
+<!-- ✅ Good - consistent lengths -->
+
+Signature: ************\_\_************ Date: ********\_\_\_\_********
+
+<!-- ❌ Avoid - inconsistent lengths -->
+
+Signature: ******\_****** Date: **\_\_\_**
+```
+
+### 2. Minimum 10 Underscores
+
+Use at least 10 underscores to ensure detection:
+
+```markdown
+<!-- ✅ Good - 10+ underscores -->
+
+Signature: ****\_\_****
+
+<!-- ❌ Won't be detected - only 9 underscores -->
+
+Signature: ****\_****
+```
+
+### 3. Label Signature Lines
+
+Always label what each signature line is for:
+
+```markdown
+<!-- ✅ Good - clear labels -->
+
+**Client Representative** Signature: ************\_\_************ Date:
+********\_\_\_\_********
+
+<!-- ❌ Avoid - unlabeled -->
+
+---
+
+---
+```
+
+### 4. Group Related Signatures
+
+Keep related signature lines together:
+
+```markdown
+**Party A**
+
+Name: ************\_\_************ Signature: ************\_\_************ Date:
+********\_\_\_\_********
+```
+
+### 5. Add Spacing
+
+Add whitespace around signature blocks for readability:
+
+```markdown
+## SIGNATURES
+
+---
+
+**Client**
+
+Signature: ************\_\_************
+
+---
+
+**Provider**
+
+Signature: ************\_\_************
+```
+
+### 6. Print Considerations
+
+Test your signature lines in print preview to ensure adequate space:
+
+```markdown
+<!-- Provide enough underscores for physical signatures -->
+
+Signature: ************\_\_************ <!-- ~26 underscores = ~3 inches -->
+```
+
+### 7. Accessibility
+
+Include descriptive text near signature lines:
+
+```markdown
+**Sign below to indicate agreement:**
+
+Signature: ************\_\_************
+```
+
+## Advanced Usage
+
+### Combining with Field Tracking
+
+When field tracking is enabled, signature lines are preserved:
+
+```markdown
+---
+enableFieldTracking: true
+---
+
+Client: {{client_name}} Signature: ************\_\_************
+```
+
+The signature line will be wrapped with CSS while the `{{client_name}}` field is
+tracked separately.
+
+### Dynamic Signature Blocks
+
+Use template loops to generate multiple signature lines:
+
+```yaml
+---
+parties:
+  - name: 'Client A'
+    role: 'Buyer'
+  - name: 'Client B'
+    role: 'Seller'
+---
+```
+
+```markdown
+{{#parties}} **{{name}}** ({{role}})
+
+Signature: ************\_\_************
+
+Date: ********\_\_\_\_********
+
+{{/parties}}
+```
+
+### Conditional Signatures
+
+Show signature lines only when needed:
+
+```markdown
+{{#if requires_witness}} **Witness**
+
+Signature: ************\_\_************
+
+Date: ********\_\_\_\_******** {{/if}}
+```
+
+## Integration with Other Features
+
+### With Cross-References
+
+```markdown
+As stated in Section |introduction|, the parties agree to the terms below.
+
+**Signatures** (see |signatures|)
+
+|signatures| **Client**: ************\_\_************
+```
+
+### With Headers
+
+```markdown
+l. Agreement Terms
+
+ll. Signatures
+
+lll. Client Signature
+
+---
+```
+
+## Troubleshooting
+
+### Signature Lines Not Detected
+
+**Problem**: Underscores are not being wrapped with CSS class.
+
+**Solutions**:
+
+1. Ensure you have at least 10 consecutive underscores
+2. Check that signature lines are not inside code blocks
+3. Verify the plugin is enabled in your pipeline
+
+### Underscores Escaped in Output
+
+**Problem**: Output shows `\_\_\_\_` instead of `____`.
+
+**Solution**: This is normal behavior when CSS wrapping is disabled. Enable
+`addCssClass: true` to preserve underscores in HTML.
+
+### Styling Not Applied
+
+**Problem**: Signature lines appear as plain underscores in output.
+
+**Solution**: Add CSS rules for the `.signature-line` class to your stylesheet.
+
+### Lines Too Short/Long
+
+**Problem**: Signature lines are not the right length when printed.
+
+**Solution**: Adjust the number of underscores or use CSS to set `min-width`:
+
+```css
+.signature-line {
+  min-width: 3in; /* Adjust as needed */
+}
+```
+
+## See Also
+
+- [Field Tracking](../processing/field-tracking.md) - Track template fields
+- [CSS Classes](../output/css-classes.md) - Available CSS classes
+- [HTML Generation](../output/html-generation.md) - HTML output options
+- [PDF Generation](../output/pdf-generation.md) - PDF output with signatures

--- a/src/extensions/remark/legal-markdown-processor.ts
+++ b/src/extensions/remark/legal-markdown-processor.ts
@@ -45,6 +45,7 @@ import {
   remarkLegalHeadersParser,
   remarkDates,
 } from '../../plugins/remark/index';
+import remarkSignatureLines from '../../plugins/remark/signature-lines';
 import { remarkDebugAST } from '../../plugins/remark/debug-ast';
 import { fieldTracker } from '../tracking/field-tracker';
 import { parseYamlFrontMatter } from '../../core/parsers/yaml-parser';
@@ -198,6 +199,14 @@ function createLegalMarkdownProcessor(
     metadata,
     debug: options.debug,
     enableFieldTracking: options.enableFieldTracking,
+  });
+
+  // Add signature lines plugin (wraps long underscore sequences with CSS class)
+  processor.use(remarkSignatureLines, {
+    minUnderscores: 10,
+    addCssClass: true,
+    cssClassName: 'signature-line',
+    debug: options.debug,
   });
 
   // Add template fields plugin (processes {{field}} patterns)

--- a/src/plugins/remark/signature-lines.ts
+++ b/src/plugins/remark/signature-lines.ts
@@ -56,6 +56,32 @@ const DEFAULT_OPTIONS: Required<SignatureLinesOptions> = {
 };
 
 /**
+ * Sanitize CSS class name to prevent XSS vulnerabilities
+ *
+ * Ensures the class name only contains valid CSS identifier characters:
+ * - Letters (a-z, A-Z)
+ * - Digits (0-9)
+ * - Hyphens (-)
+ * - Underscores (_)
+ *
+ * @param className - The class name to sanitize
+ * @returns Sanitized class name, or default if invalid
+ */
+function sanitizeCssClassName(className: string): string {
+  // Valid CSS identifier pattern: starts with letter/underscore, followed by letters/digits/hyphens/underscores
+  const validPattern = /^[a-zA-Z_][\w-]*$/;
+
+  if (!className || !validPattern.test(className)) {
+    console.warn(
+      `[signature-lines] Invalid CSS class name "${className}", using default "signature-line"`
+    );
+    return 'signature-line';
+  }
+
+  return className;
+}
+
+/**
  * Remark plugin that detects and marks signature lines
  *
  * This plugin processes text nodes in the markdown AST and identifies sequences
@@ -76,6 +102,9 @@ const DEFAULT_OPTIONS: Required<SignatureLinesOptions> = {
  */
 const remarkSignatureLines: Plugin<[SignatureLinesOptions?], Root> = (options = {}) => {
   const config = { ...DEFAULT_OPTIONS, ...options };
+
+  // Sanitize CSS class name to prevent XSS
+  const safeCssClassName = sanitizeCssClassName(config.cssClassName);
 
   return (tree: Root) => {
     if (config.debug) {
@@ -109,7 +138,7 @@ const remarkSignatureLines: Plugin<[SignatureLinesOptions?], Root> = (options = 
         if (config.debug) {
           console.log(`[signature-lines] Wrapping ${match.length} underscores`);
         }
-        return `<span class="${config.cssClassName}">${match}</span>`;
+        return `<span class="${safeCssClassName}">${match}</span>`;
       });
 
       // Replace the text node with an HTML node containing the wrapped signature lines

--- a/src/plugins/remark/signature-lines.ts
+++ b/src/plugins/remark/signature-lines.ts
@@ -1,0 +1,131 @@
+/**
+ * Remark plugin for signature lines
+ *
+ * Detects long sequences of underscores (10 or more consecutive) and wraps them
+ * in HTML spans with a CSS class for styling. This is commonly used in legal
+ * documents to indicate signature lines.
+ *
+ * @example
+ * Input:  "Signature: __________________________"
+ * Output: "Signature: <span class=\"signature-line\">__________________________</span>"
+ *
+ * @module plugins/remark/signature-lines
+ */
+
+import { visit } from 'unist-util-visit';
+import type { Plugin } from 'unified';
+import type { Root, Text, HTML } from 'mdast';
+
+/**
+ * Options for the signature lines plugin
+ */
+export interface SignatureLinesOptions {
+  /**
+   * Minimum number of consecutive underscores to treat as a signature line
+   * @default 10
+   */
+  minUnderscores?: number;
+
+  /**
+   * Whether to add CSS class to signature lines
+   * @default true
+   */
+  addCssClass?: boolean;
+
+  /**
+   * Custom CSS class name for signature lines
+   * @default "signature-line"
+   */
+  cssClassName?: string;
+
+  /**
+   * Whether to enable debug logging
+   * @default false
+   */
+  debug?: boolean;
+}
+
+/**
+ * Default options for the plugin
+ */
+const DEFAULT_OPTIONS: Required<SignatureLinesOptions> = {
+  minUnderscores: 10,
+  addCssClass: true,
+  cssClassName: 'signature-line',
+  debug: false,
+};
+
+/**
+ * Remark plugin that detects and marks signature lines
+ *
+ * This plugin processes text nodes in the markdown AST and identifies sequences
+ * of underscores that are likely signature lines (by default, 10 or more consecutive
+ * underscores). When found, it wraps them in HTML span elements with a CSS class
+ * for styling.
+ *
+ * @param options - Configuration options for the plugin
+ * @returns A unified transformer function
+ *
+ * @example
+ * ```typescript
+ * unified()
+ *   .use(remarkParse)
+ *   .use(remarkSignatureLines, { minUnderscores: 15 })
+ *   .use(remarkStringify)
+ * ```
+ */
+const remarkSignatureLines: Plugin<[SignatureLinesOptions?], Root> = (options = {}) => {
+  const config = { ...DEFAULT_OPTIONS, ...options };
+
+  return (tree: Root) => {
+    if (config.debug) {
+      console.log('[signature-lines] Processing tree...');
+    }
+
+    visit(tree, 'text', (node: Text, index, parent) => {
+      if (index === undefined || !parent) return;
+
+      const text = node.value;
+
+      // Create regex pattern for detecting long underscore sequences
+      const underscorePattern = new RegExp(`_{${config.minUnderscores},}`, 'g');
+
+      // Check if text contains signature lines
+      if (!underscorePattern.test(text)) {
+        return; // No signature lines found, skip this node
+      }
+
+      if (config.debug) {
+        console.log('[signature-lines] Found signature line in text:', text);
+      }
+
+      // If we're not adding CSS classes, leave the text as-is
+      if (!config.addCssClass) {
+        return;
+      }
+
+      // Process the text and wrap signature lines in HTML spans
+      const processedText = text.replace(underscorePattern, match => {
+        if (config.debug) {
+          console.log(`[signature-lines] Wrapping ${match.length} underscores`);
+        }
+        return `<span class="${config.cssClassName}">${match}</span>`;
+      });
+
+      // Replace the text node with an HTML node containing the wrapped signature lines
+      const htmlNode: HTML = {
+        type: 'html',
+        value: processedText,
+      };
+
+      // Replace the text node with the new HTML node
+      parent.children[index] = htmlNode;
+    });
+
+    if (config.debug) {
+      console.log('[signature-lines] Processing complete');
+    }
+  };
+};
+
+export default remarkSignatureLines;

--- a/src/web/examples.js
+++ b/src/web/examples.js
@@ -658,6 +658,22 @@ Applicable tax rate is \{\{formatPercent(tax_rate, 1)\}\} as determined by \{\{j
 ll. Governing Law
 This Agreement shall be governed by the laws of \{\{jurisdiction\}\}.
 
+l. Signature Lines
+
+Legal Markdown automatically detects and styles signature lines (10+ underscores):
+
+ll. Basic Signature Block
+**Client Representative**
+
+Signature: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+Date: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+ll. Multiple Signatures
+Client: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_ Date: \_\_\_\_\_\_\_\_\_\_
+
+Witness: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_ Date: \_\_\_\_\_\_\_\_\_\_
+
 l. Document Summary
 
 **Document Information:**

--- a/tests/unit/plugins/remark/signature-lines.unit.test.ts
+++ b/tests/unit/plugins/remark/signature-lines.unit.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Unit tests for remark signature lines plugin
+ *
+ * Tests the signature line detection and wrapping functionality including
+ * various underscore lengths, CSS class application, and edge cases.
+ *
+ * @module
+ */
+
+import { describe, it, expect } from 'vitest';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkStringify from 'remark-stringify';
+import remarkSignatureLines from '../../../../src/plugins/remark/signature-lines';
+
+describe('remarkSignatureLines Plugin', () => {
+  describe('Basic Signature Line Detection', () => {
+    it('should wrap 10 consecutive underscores with CSS class', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const input = 'Signature: __________';
+      const result = await processor.process(input);
+
+      expect(result.toString().trim()).toBe(
+        'Signature: <span class="signature-line">__________</span>'
+      );
+    });
+
+    it('should wrap 20 consecutive underscores with CSS class', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const input = 'Signature: ____________________';
+      const result = await processor.process(input);
+
+      expect(result.toString().trim()).toBe(
+        'Signature: <span class="signature-line">____________________</span>'
+      );
+    });
+
+    it('should not wrap 9 consecutive underscores (below minimum)', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const input = 'Signature: _________';
+      const result = await processor.process(input);
+
+      expect(result.toString().trim()).toBe('Signature: \\_\\_\\_\\_\\_\\_\\_\\_\\_');
+    });
+
+    it('should handle multiple signature lines in same text', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const input = 'Client: __________ Date: __________';
+      const result = await processor.process(input);
+
+      expect(result.toString().trim()).toBe(
+        'Client: <span class="signature-line">__________</span> Date: <span class="signature-line">__________</span>'
+      );
+    });
+  });
+
+  describe('Custom Configuration', () => {
+    it('should respect custom minUnderscores threshold', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines, { minUnderscores: 15 })
+        .use(remarkStringify);
+
+      const input = 'Signature: _______________'; // 15 underscores
+      const result = await processor.process(input);
+
+      expect(result.toString().trim()).toBe(
+        'Signature: <span class="signature-line">_______________</span>'
+      );
+    });
+
+    it('should not wrap underscores below custom threshold', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines, { minUnderscores: 15 })
+        .use(remarkStringify);
+
+      const input = 'Signature: ______________'; // 14 underscores
+      const result = await processor.process(input);
+
+      expect(result.toString().trim()).toContain('Signature:');
+      expect(result.toString().trim()).not.toContain('<span');
+    });
+
+    it('should use custom CSS class name', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines, { cssClassName: 'custom-sig-line' })
+        .use(remarkStringify);
+
+      const input = 'Signature: __________';
+      const result = await processor.process(input);
+
+      expect(result.toString().trim()).toBe(
+        'Signature: <span class="custom-sig-line">__________</span>'
+      );
+    });
+
+    it('should not add CSS class when disabled', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines, { addCssClass: false })
+        .use(remarkStringify);
+
+      const input = 'Signature: __________';
+      const result = await processor.process(input);
+
+      // When CSS class is disabled, remark-stringify will escape the underscores
+      // The important thing is that no <span> tag is added
+      expect(result.toString().trim()).not.toContain('<span');
+      expect(result.toString().trim()).toContain('Signature:');
+    });
+  });
+
+  describe('Real-world Document Scenarios', () => {
+    it('should process signature blocks in legal documents', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const input = `# Agreement
+
+**SIGNATURES**
+
+**Client Representative**
+
+Signature: __________________________
+
+Date: ____________________
+
+**Service Provider**
+
+Signature: __________________________
+
+Date: ____________________`;
+
+      const result = await processor.process(input);
+      const output = result.toString();
+
+      // Should wrap all 4 signature lines
+      const signatureSpans = (output.match(/<span class="signature-line">/g) || []).length;
+      expect(signatureSpans).toBe(4);
+
+      // Should preserve structure
+      expect(output).toContain('# Agreement');
+      expect(output).toContain('**SIGNATURES**');
+      expect(output).toContain('**Client Representative**');
+    });
+
+    it('should handle signature lines in lists', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const input = `- Client Name: __________________________
+- Client Signature: __________________________
+- Date: ____________________`;
+
+      const result = await processor.process(input);
+      const output = result.toString();
+
+      // Should wrap all 3 signature lines
+      const signatureSpans = (output.match(/<span class="signature-line">/g) || []).length;
+      expect(signatureSpans).toBe(3);
+    });
+
+    it('should handle signature lines in tables', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const input = `| Party | Signature | Date |
+|-------|-----------|------|
+| Client A | __________________________ | __________ |
+| Client B | __________________________ | __________ |`;
+
+      const result = await processor.process(input);
+      const output = result.toString();
+
+      // Should wrap all signature lines in the table
+      const signatureSpans = (output.match(/<span class="signature-line">/g) || []).length;
+      expect(signatureSpans).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle empty input', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const input = '';
+      const result = await processor.process(input);
+
+      expect(result.toString().trim()).toBe('');
+    });
+
+    it('should handle input with no underscores', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const input = 'This document has no signature lines.';
+      const result = await processor.process(input);
+
+      expect(result.toString().trim()).toBe('This document has no signature lines.');
+    });
+
+    it('should handle very long underscore sequences', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const longUnderscores = '_'.repeat(100);
+      const input = `Signature: ${longUnderscores}`;
+      const result = await processor.process(input);
+
+      expect(result.toString()).toContain('<span class="signature-line">');
+      expect(result.toString()).toContain('_'.repeat(100));
+    });
+
+    it('should handle underscores in code blocks (should not process)', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const input = '```\nlet signature = "__________";\n```';
+      const result = await processor.process(input);
+
+      // Code blocks should not be processed
+      expect(result.toString()).not.toContain('<span class="signature-line">');
+    });
+
+    it('should handle underscores in inline code (should not process)', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const input = 'Use `__________` for signatures.';
+      const result = await processor.process(input);
+
+      // Inline code should not be processed
+      expect(result.toString()).not.toContain('<span class="signature-line">');
+    });
+
+    it('should handle mixed content with signature lines', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const input = `This is a paragraph.
+
+Signature: __________
+
+This is another paragraph.`;
+
+      const result = await processor.process(input);
+      const output = result.toString();
+
+      expect(output).toContain('<span class="signature-line">__________</span>');
+      expect(output).toContain('This is a paragraph.');
+      expect(output).toContain('This is another paragraph.');
+    });
+  });
+
+  describe('Integration with Other Formatting', () => {
+    it('should work with bold text', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const input = '**Signature:** __________';
+      const result = await processor.process(input);
+
+      expect(result.toString().trim()).toContain('**Signature:**');
+      expect(result.toString().trim()).toContain('<span class="signature-line">__________</span>');
+    });
+
+    it('should work with italic text', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const input = '*Sign here:* __________';
+      const result = await processor.process(input);
+
+      expect(result.toString().trim()).toContain('*Sign here:*');
+      expect(result.toString().trim()).toContain('<span class="signature-line">__________</span>');
+    });
+
+    it('should work with links', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines)
+        .use(remarkStringify);
+
+      const input = '[Print and sign](example.com): __________';
+      const result = await processor.process(input);
+
+      expect(result.toString().trim()).toContain('[Print and sign]');
+      expect(result.toString().trim()).toContain('<span class="signature-line">__________</span>');
+    });
+  });
+
+  describe('Debug Mode', () => {
+    it('should not throw errors when debug is enabled', async () => {
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkSignatureLines, { debug: true })
+        .use(remarkStringify);
+
+      const input = 'Signature: __________';
+
+      // Should not throw
+      await expect(processor.process(input)).resolves.toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements automatic detection and CSS wrapping of signature lines in legal documents. Detects sequences of 10+ consecutive underscores and wraps them with `<span class="signature-line">` for consistent styling.

## Features

- ✨ Automatic detection of signature lines (10+ underscores by default)
- 🎨 Wraps detected lines with CSS class for styling
- ⚙️ Configurable threshold, CSS class name, and behavior
- 🔧 Integrated into remark processing pipeline
- 📝 Preserves code blocks and inline code

## Implementation Details

### Plugin
- New `remarkSignatureLines` plugin in `src/plugins/remark/signature-lines.ts`
- Configuration options:
  - `minUnderscores`: Minimum consecutive underscores (default: 10)
  - `addCssClass`: Enable/disable CSS wrapping (default: true)
  - `cssClassName`: Custom CSS class name (default: "signature-line")
  - `debug`: Enable debug logging

### Integration
- Added to `legal-markdown-processor.ts` pipeline after dates plugin
- Processes text nodes while preserving structure
- Does not process code blocks or inline code

## Testing

✅ **21 comprehensive unit tests - all passing**

Coverage includes:
- Basic detection with various lengths (10, 20, 100+ underscores)
- Custom configuration options
- Real-world scenarios (signature blocks, lists, tables)
- Edge cases (empty input, code blocks, very long sequences)
- Integration with formatting (bold, italic, links)

## Documentation

📚 **Complete documentation added**

- Full feature guide: `docs/features/signature-lines.md`
- Usage examples for common scenarios
- CSS styling guide with print optimization
- Best practices and troubleshooting
- Added to features README

## Examples

Updated playground examples:
- Added dedicated section in features-demo example
- Shows basic signature blocks and multiple signatures
- Existing signature blocks in contracts now automatically styled

## Use Cases

- Legal document signature blocks
- Contract execution pages
- Witness and notary sections
- Any document requiring signature lines

## Example Usage

**Input:**
```markdown
**Client Representative**

Signature: __________________________

Date: ____________________
```

**Output:**
```markdown
**Client Representative**

Signature: <span class="signature-line">__________________________</span>

Date: <span class="signature-line">____________________</span>
```

## CSS Styling

Users can style signature lines with:

```css
.signature-line {
  display: inline-block;
  border-bottom: 1px solid #000;
  min-width: 200px;
}
```

## Breaking Changes

None - this is a new feature that enhances existing functionality.