### PR TITLE
fix: process mixins and headers correctly in imported files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "legal-markdown-js",
-  "version": "3.2.1",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "legal-markdown-js",
-      "version": "3.2.1",
+      "version": "3.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2008,14 +2008,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
       "integrity": "sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==",
-      "cpu": [
-        "ppc64"
-      ],
+      "cpu": ["ppc64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "aix"
-      ],
+      "os": ["aix"],
       "engines": {
         "node": ">=18"
       }
@@ -2024,14 +2020,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.8.tgz",
       "integrity": "sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==",
-      "cpu": [
-        "arm"
-      ],
+      "cpu": ["arm"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
+      "os": ["android"],
       "engines": {
         "node": ">=18"
       }
@@ -2040,14 +2032,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz",
       "integrity": "sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
+      "os": ["android"],
       "engines": {
         "node": ">=18"
       }
@@ -2056,14 +2044,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.8.tgz",
       "integrity": "sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
+      "os": ["android"],
       "engines": {
         "node": ">=18"
       }
@@ -2072,14 +2056,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.8.tgz",
       "integrity": "sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": ">=18"
       }
@@ -2088,14 +2068,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz",
       "integrity": "sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": ">=18"
       }
@@ -2104,14 +2080,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz",
       "integrity": "sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "freebsd"
-      ],
+      "os": ["freebsd"],
       "engines": {
         "node": ">=18"
       }
@@ -2120,14 +2092,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz",
       "integrity": "sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "freebsd"
-      ],
+      "os": ["freebsd"],
       "engines": {
         "node": ">=18"
       }
@@ -2136,14 +2104,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz",
       "integrity": "sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==",
-      "cpu": [
-        "arm"
-      ],
+      "cpu": ["arm"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=18"
       }
@@ -2152,14 +2116,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz",
       "integrity": "sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=18"
       }
@@ -2168,14 +2128,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz",
       "integrity": "sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==",
-      "cpu": [
-        "ia32"
-      ],
+      "cpu": ["ia32"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=18"
       }
@@ -2184,14 +2140,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz",
       "integrity": "sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==",
-      "cpu": [
-        "loong64"
-      ],
+      "cpu": ["loong64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=18"
       }
@@ -2200,14 +2152,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz",
       "integrity": "sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==",
-      "cpu": [
-        "mips64el"
-      ],
+      "cpu": ["mips64el"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=18"
       }
@@ -2216,14 +2164,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz",
       "integrity": "sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==",
-      "cpu": [
-        "ppc64"
-      ],
+      "cpu": ["ppc64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=18"
       }
@@ -2232,14 +2176,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz",
       "integrity": "sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==",
-      "cpu": [
-        "riscv64"
-      ],
+      "cpu": ["riscv64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=18"
       }
@@ -2248,14 +2188,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz",
       "integrity": "sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==",
-      "cpu": [
-        "s390x"
-      ],
+      "cpu": ["s390x"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=18"
       }
@@ -2264,14 +2200,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz",
       "integrity": "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=18"
       }
@@ -2280,14 +2212,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz",
       "integrity": "sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "netbsd"
-      ],
+      "os": ["netbsd"],
       "engines": {
         "node": ">=18"
       }
@@ -2296,14 +2224,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz",
       "integrity": "sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "netbsd"
-      ],
+      "os": ["netbsd"],
       "engines": {
         "node": ">=18"
       }
@@ -2312,14 +2236,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz",
       "integrity": "sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "openbsd"
-      ],
+      "os": ["openbsd"],
       "engines": {
         "node": ">=18"
       }
@@ -2328,14 +2248,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz",
       "integrity": "sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "openbsd"
-      ],
+      "os": ["openbsd"],
       "engines": {
         "node": ">=18"
       }
@@ -2344,14 +2260,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz",
       "integrity": "sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "openharmony"
-      ],
+      "os": ["openharmony"],
       "engines": {
         "node": ">=18"
       }
@@ -2360,14 +2272,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz",
       "integrity": "sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "sunos"
-      ],
+      "os": ["sunos"],
       "engines": {
         "node": ">=18"
       }
@@ -2376,14 +2284,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz",
       "integrity": "sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "win32"
-      ],
+      "os": ["win32"],
       "engines": {
         "node": ">=18"
       }
@@ -2392,14 +2296,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz",
       "integrity": "sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==",
-      "cpu": [
-        "ia32"
-      ],
+      "cpu": ["ia32"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "win32"
-      ],
+      "os": ["win32"],
       "engines": {
         "node": ">=18"
       }
@@ -2408,14 +2308,10 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz",
       "integrity": "sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "license": "MIT",
       "optional": true,
-      "os": [
-        "win32"
-      ],
+      "os": ["win32"],
       "engines": {
         "node": ">=18"
       }
@@ -2607,6 +2503,15 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.0.tgz",
+      "integrity": "sha512-JWaTfCxI1eTmJ1BIv86vUfjVatOdxwD0DAVKYevY8SazeUUZtW+tNbsdejVO1GYE0GXJW1N1ahmiC3TFd+7wZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@inquirer/checkbox": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.0.tgz",
@@ -2653,14 +2558,14 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
-      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.2.2.tgz",
+      "integrity": "sha512-yXq/4QUnk4sHMtmbd7irwiepjB8jXU0kkFRL4nr/aDBA2mDz13cMakEWdDwX3eSCTkk03kwcndD1zfRAIlELxA==",
       "license": "MIT",
       "dependencies": {
+        "@inquirer/ansi": "^1.0.0",
         "@inquirer/figures": "^1.0.13",
         "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
         "signal-exit": "^4.1.0",
@@ -2724,14 +2629,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.15.tgz",
-      "integrity": "sha512-wst31XT8DnGOSS4nNJDIklGKnf+8shuauVrWzgKegWUe28zfCftcWZ2vktGdzJgcylWSS2SrDnYUb6alZcwnCQ==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.20.tgz",
+      "integrity": "sha512-7omh5y5bK672Q+Brk4HBbnHNowOZwrb/78IFXdrEB9PfdxL3GudQyDk8O9vQ188wj3xrEebS2M9n18BjJoI83g==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8",
-        "external-editor": "^3.1.0"
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/external-editor": "^1.0.2",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -2765,6 +2670,49 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
+      "integrity": "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.0",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor/node_modules/chardet": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@inquirer/figures": {
@@ -3405,281 +3353,201 @@
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
       "integrity": "sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==",
-      "cpu": [
-        "arm"
-      ],
+      "cpu": ["arm"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ]
+      "os": ["android"]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.2.tgz",
       "integrity": "sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ]
+      "os": ["android"]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.2.tgz",
       "integrity": "sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "darwin"
-      ]
+      "os": ["darwin"]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.2.tgz",
       "integrity": "sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "darwin"
-      ]
+      "os": ["darwin"]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.2.tgz",
       "integrity": "sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "os": ["freebsd"]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.2.tgz",
       "integrity": "sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "os": ["freebsd"]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.2.tgz",
       "integrity": "sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==",
-      "cpu": [
-        "arm"
-      ],
+      "cpu": ["arm"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.2.tgz",
       "integrity": "sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==",
-      "cpu": [
-        "arm"
-      ],
+      "cpu": ["arm"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.2.tgz",
       "integrity": "sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.2.tgz",
       "integrity": "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.2.tgz",
       "integrity": "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==",
-      "cpu": [
-        "loong64"
-      ],
+      "cpu": ["loong64"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.2.tgz",
       "integrity": "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==",
-      "cpu": [
-        "ppc64"
-      ],
+      "cpu": ["ppc64"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.2.tgz",
       "integrity": "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==",
-      "cpu": [
-        "riscv64"
-      ],
+      "cpu": ["riscv64"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.2.tgz",
       "integrity": "sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==",
-      "cpu": [
-        "riscv64"
-      ],
+      "cpu": ["riscv64"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.2.tgz",
       "integrity": "sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==",
-      "cpu": [
-        "s390x"
-      ],
+      "cpu": ["s390x"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz",
       "integrity": "sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz",
       "integrity": "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.2.tgz",
       "integrity": "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "win32"
-      ]
+      "os": ["win32"]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.2.tgz",
       "integrity": "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==",
-      "cpu": [
-        "ia32"
-      ],
+      "cpu": ["ia32"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "win32"
-      ]
+      "os": ["win32"]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.2.tgz",
       "integrity": "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "win32"
-      ]
+      "os": ["win32"]
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -7346,6 +7214,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/check-error": {
@@ -7927,9 +7796,7 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
+      "engines": ["node >= 0.8"],
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -9732,6 +9599,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chardet": "^0.7.0",
@@ -9746,6 +9614,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -10173,9 +10042,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -11980,9 +11847,7 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "dev": true,
-      "engines": [
-        "node >= 0.2.0"
-      ],
+      "engines": ["node >= 0.2.0"],
       "license": "MIT"
     },
     "node_modules/JSONStream": {
@@ -13573,9 +13438,7 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.7.tgz",
       "integrity": "sha512-2OfDPL+e03E0LrXaGYOtTFIYhiuzep94NSsuhrNULq+stylcJedcHdzHtz0atMUuGwJfFYs0YL5xeC/Ca2x0eQ==",
       "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa"
-      ],
+      "funding": ["https://github.com/sponsors/broofa"],
       "license": "MIT",
       "bin": {
         "mime": "bin/cli.js"
@@ -14003,13 +13866,7 @@
       ],
       "dev": true,
       "license": "Artistic-2.0",
-      "workspaces": [
-        "docs",
-        "smoke-tests",
-        "mock-globals",
-        "mock-registry",
-        "workspaces/*"
-      ],
+      "workspaces": ["docs", "smoke-tests", "mock-globals", "mock-registry", "workspaces/*"],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/arborist": "^8.0.1",
@@ -15139,9 +14996,7 @@
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
       "dev": true,
-      "engines": [
-        "node >= 0.2.0"
-      ],
+      "engines": ["node >= 0.2.0"],
       "inBundle": true,
       "license": "MIT"
     },
@@ -16765,6 +16620,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -20150,9 +20006,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
@@ -20531,14 +20387,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -20548,11 +20404,14 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -20609,6 +20468,7 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "os-tmpdir": "~1.0.2"
@@ -21673,18 +21533,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.6.tgz",
-      "integrity": "sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==",
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.9.tgz",
+      "integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
-        "fdir": "^6.4.6",
+        "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
-        "rollup": "^4.40.0",
-        "tinyglobby": "^0.2.14"
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -21771,11 +21631,14 @@
       }
     },
     "node_modules/vite/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },

--- a/src/extensions/generators/html-generator.ts
+++ b/src/extensions/generators/html-generator.ts
@@ -38,6 +38,16 @@ import { logger } from '../../utils/logger';
 import { RESOLVED_PATHS } from '../../constants/index';
 
 /**
+ * Pattern to match escaped less-than characters from remarkStringify
+ */
+const ESCAPED_LT_PATTERN = /\\</g;
+
+/**
+ * Pattern to match escaped greater-than characters from remarkStringify
+ */
+const ESCAPED_GT_PATTERN = /\\>/g;
+
+/**
  * Configuration options for HTML generation
  *
  * @interface HtmlGeneratorOptions
@@ -194,7 +204,9 @@ export class HtmlGenerator {
       // Pre-process: unescape backslash-escaped HTML from remarkStringify
       // remarkStringify escapes HTML as \< and \>, we need to unescape them
       // Pattern: \<div class="...">\</div> -> <div class="..."></div>
-      const processedMarkdown = contentWithoutFrontmatter.replace(/\\</g, '<').replace(/\\>/g, '>');
+      const processedMarkdown = contentWithoutFrontmatter
+        .replace(ESCAPED_LT_PATTERN, '<')
+        .replace(ESCAPED_GT_PATTERN, '>');
 
       // Convert markdown to HTML
       let htmlContent = await marked.parse(processedMarkdown);

--- a/src/plugins/remark/imports.ts
+++ b/src/plugins/remark/imports.ts
@@ -39,6 +39,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { parseYamlFrontMatter } from '../../core/parsers/yaml-parser';
 import { mergeSequentially, MergeOptions, MergeResult } from '../../core/utils/frontmatter-merger';
+import { processMixins } from '../../core/processors/mixin-processor';
 
 /**
  * Options for the remark imports plugin
@@ -142,6 +143,9 @@ interface ImportContext {
 
   /** List of successfully imported files */
   importedFiles: string[];
+
+  /** Accumulated metadata from all imports (for mixin expansion) */
+  accumulatedMetadata: Record<string, any>;
 }
 
 /**
@@ -223,6 +227,7 @@ export const remarkImports: Plugin<[RemarkImportsOptions], Root> = options => {
       contentCache: new Map(),
       importedMetadataList: [],
       importedFiles: [],
+      accumulatedMetadata: {}, // Initialize with empty metadata
     };
 
     // Process all text nodes that might contain import directives
@@ -356,6 +361,13 @@ function processImportDirective(directive: ImportDirective, context: ImportConte
         metadata,
         source: normalizedPath,
       });
+
+      // Accumulate metadata for mixin expansion in imported content
+      // Merge the new metadata into accumulated metadata (shallow merge)
+      context.accumulatedMetadata = {
+        ...context.accumulatedMetadata,
+        ...metadata,
+      };
 
       // Track imported file
       if (!context.importedFiles.includes(normalizedPath)) {
@@ -524,29 +536,129 @@ function extractSection(content: string, sectionName: string, debug: boolean): s
 }
 
 /**
+ * Expand mixins with field tracking spans
+ *
+ * Expands {{field}} patterns and wraps the results in HTML spans for field tracking,
+ * similar to what remarkTemplateFields does. This ensures imported mixins have proper
+ * field highlighting support.
+ *
+ * @param content - Content with {{field}} patterns
+ * @param metadata - Metadata to resolve field values
+ * @returns Content with expanded mixins wrapped in tracking spans
+ */
+function expandMixinsWithTracking(content: string, metadata: Record<string, any>): string {
+  const mixinPattern = /\{\{([^}]+)\}\}/g;
+
+  return content.replace(mixinPattern, (match, fieldExpression) => {
+    const trimmedField = fieldExpression.trim();
+
+    // Try to resolve the field value
+    let value: any;
+    let hasValue = false;
+
+    try {
+      // Use processMixins to handle the complex logic (helpers, dot notation, etc.)
+      const expandedValue = processMixins(match, metadata, {});
+
+      // Check if the mixin was actually expanded (processMixins returns original if not found)
+      if (expandedValue !== match) {
+        value = expandedValue;
+        hasValue = true;
+      }
+    } catch (error) {
+      // If resolution fails, leave as is for remarkTemplateFields to process
+    }
+
+    // Only expand mixins that we found in imported metadata
+    // Leave others unchanged so remarkTemplateFields can process them with main metadata
+    if (hasValue) {
+      // Detect if this is a formula/helper (contains function call) or a simple field
+      // Helpers: formatPercent(...), formatDate(...), etc.
+      // Conditionals: field ? value1 : value2
+      const hasLogic =
+        /^[a-zA-Z_][a-zA-Z0-9_]*\s*\(/.test(trimmedField) || // Function call: formatPercent(...)
+        /\?.*:/.test(trimmedField); // Conditional: field ? a : b
+
+      // Use appropriate CSS class based on whether it's a formula or simple field
+      const cssClass = hasLogic ? 'legal-field highlight' : 'legal-field imported-value';
+
+      // Value was found in imported metadata - expand and track
+      return `<span class="${cssClass}" data-field="${trimmedField}">${value}</span>`;
+    } else {
+      // Value not in imported metadata - leave unchanged for main pipeline processing
+      return match;
+    }
+  });
+}
+
+/**
+ * Strip HTML comments and wrapper tags from imported content
+ *
+ * This is a temporary workaround because remarkImports inserts content as plain text
+ * (not AST nodes), which causes HTML to be escaped when rendered.
+ *
+ * We strip:
+ * - HTML comments: <!-- ... -->
+ * - Standalone wrapper tags WITHOUT attributes: <p>, <div>, <span> (only when wrapping headers)
+ * - We PRESERVE tags WITH attributes (class, id, style) as they may be needed for styling
+ *
+ * TODO: Fix the root cause by making remarkImports insert content as proper AST nodes
+ * See: https://github.com/petalo/legal-markdown-js/issues/119
+ */
+function stripHtmlComments(content: string): string {
+  let processed = content;
+
+  // Remove HTML comments (<!-- ... -->)
+  // Use non-greedy match to handle multiple comments on same line
+  processed = processed.replace(/<!--[\s\S]*?-->/g, '');
+
+  // Remove standalone wrapper tags WITHOUT attributes that contain legal headers
+  // Pattern: <p>\nll. Header\n</p> (but NOT <p class="...">\nll. Header\n</p>)
+  // This prevents plain tags from being escaped while preserving styled tags
+  // The negative lookahead (?!\s+[a-z]) ensures we only match tags without attributes
+  processed = processed.replace(
+    /<(p|div|span)(?!\s+[a-z])\s*>\s*(l{1,9}\.\s+[^\n]+)\s*<\/\1>/gi,
+    '$2'
+  );
+
+  // Also remove wrapper tags on same line: <p>ll. Header</p> (but not <p class="...">ll. Header</p>)
+  processed = processed.replace(/<(p|div|span)(?!\s+[a-z])\s*>(l{1,9}\.\s+[^<]+)<\/\1>/gi, '$2');
+
+  return processed;
+}
+
+/**
  * Process nested imports in content
  */
 function processNestedImports(content: string, context: ImportContext): string {
   const importDirectives = extractImportDirectives(content);
 
-  if (importDirectives.length === 0) {
-    return content;
-  }
-
-  // Process directives in reverse order to maintain correct positions
   let processedContent = content;
-  for (let i = importDirectives.length - 1; i >= 0; i--) {
-    const directive = importDirectives[i];
-    const result = processImportDirective(directive, context);
 
-    // Replace the directive with the result
-    processedContent =
-      processedContent.substring(0, directive.start) +
-      result +
-      processedContent.substring(directive.end);
+  if (importDirectives.length > 0) {
+    // Process directives in reverse order to maintain correct positions
+    for (let i = importDirectives.length - 1; i >= 0; i--) {
+      const directive = importDirectives[i];
+      const result = processImportDirective(directive, context);
+
+      // Replace the directive with the result
+      processedContent =
+        processedContent.substring(0, directive.start) +
+        result +
+        processedContent.substring(directive.end);
+    }
   }
 
-  return processedContent;
+  // Expand mixins using accumulated metadata from imported files
+  // This allows mixins defined in imported file frontmatter to work
+  // We use processMixins but then wrap values in HTML spans for field tracking
+  if (context.mergeMetadata && Object.keys(context.accumulatedMetadata).length > 0) {
+    processedContent = expandMixinsWithTracking(processedContent, context.accumulatedMetadata);
+  }
+
+  // Strip HTML comments from imported content to prevent escaping
+  // (temporary workaround - see stripHtmlComments function comment)
+  return stripHtmlComments(processedContent);
 }
 
 export default remarkImports;

--- a/tests/integration/imports-with-headers.integration.test.ts
+++ b/tests/integration/imports-with-headers.integration.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Integration test for imports with legal headers
+ * Tests that headers in imported files are correctly converted
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { processLegalMarkdownWithRemark } from '../../src/extensions/remark/legal-markdown-processor';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+describe('Imports with Legal Headers Integration', () => {
+  let tempDir: string;
+  let mainFile: string;
+  let importedFile: string;
+
+  beforeAll(() => {
+    // Create temp directory
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'legal-md-test-'));
+
+    // Create imported file with headers
+    importedFile = path.join(tempDir, 'imported.md');
+    const importedContent = `
+ll. - Confidencialidad
+
+Este es un párrafo sobre confidencialidad.
+
+lll. Subsección de confidencialidad
+
+Más detalles sobre confidencialidad.
+
+llllll. - Anexo sobre VTT |anexo-vtt|
+
+Este es el contenido del anexo.
+`;
+    fs.writeFileSync(importedFile, importedContent, 'utf-8');
+
+    // Create main file that imports the other file
+    mainFile = path.join(tempDir, 'main.md');
+    const mainContent = `---
+level-two: 'Cláusula %R'
+level-three: 'Sección %n -'
+level-six: 'Anexo %R'
+---
+
+ll. - Introducción
+
+Este es el contenido principal.
+
+@import imported.md
+
+ll. - Conclusión
+
+Este es el final del documento.
+`;
+    fs.writeFileSync(mainFile, mainContent, 'utf-8');
+  });
+
+  afterAll(() => {
+    // Cleanup
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should convert headers in imported files to proper HTML headings', async () => {
+    const mainContent = fs.readFileSync(mainFile, 'utf-8');
+
+    const result = await processLegalMarkdownWithRemark(mainContent, {
+      basePath: tempDir,
+      debug: false,
+    });
+
+    // Check that headers are converted (not left as paragraphs with ll., lll., etc.)
+    expect(result.content).not.toContain('ll. - Confidencialidad');
+    expect(result.content).not.toContain('lll. Subsección');
+    expect(result.content).not.toContain('llllll. - Anexo');
+
+    // Check that headers are properly converted to markdown headings
+    expect(result.content).toContain('##'); // Level 2 headers
+    expect(result.content).toContain('###'); // Level 3 headers
+    expect(result.content).toContain('######'); // Level 6 headers
+
+    // Verify the headers have proper numbering (with flexible spacing)
+    expect(result.content).toMatch(/Cláusula\s+I/); // First level-2 header
+    expect(result.content).toMatch(/Cláusula\s+II/); // Second level-2 header (imported)
+    expect(result.content).toMatch(/Cláusula\s+III/); // Third level-2 header
+  });
+
+  it('should process headers in both main and imported files', async () => {
+    const mainContent = fs.readFileSync(mainFile, 'utf-8');
+
+    const result = await processLegalMarkdownWithRemark(mainContent, {
+      basePath: tempDir,
+      debug: false,
+    });
+
+    const lines = result.content.split('\n');
+
+    // Find all header lines
+    const headerLines = lines.filter(
+      line =>
+        line.startsWith('##') && !line.startsWith('###') && !line.startsWith('####')
+    );
+
+    // Should have exactly 3 level-2 headers (Introducción, Confidencialidad, Conclusión)
+    expect(headerLines.length).toBeGreaterThanOrEqual(3);
+
+    // Verify they are numbered sequentially (with flexible spacing)
+    expect(headerLines.some(line => /Cláusula\s+I/.test(line))).toBe(true);
+    expect(headerLines.some(line => /Cláusula\s+II/.test(line))).toBe(true);
+    expect(headerLines.some(line => /Cláusula\s+III/.test(line))).toBe(true);
+  });
+
+  it('should preserve cross-reference markers in imported headers', async () => {
+    const mainContent = fs.readFileSync(mainFile, 'utf-8');
+
+    const result = await processLegalMarkdownWithRemark(mainContent, {
+      basePath: tempDir,
+      debug: false,
+    });
+
+    // The header should be converted, but cross-reference marker should be preserved
+    // Note: The exact format depends on how cross-references are processed
+    expect(result.content).toContain('Anexo');
+  });
+});

--- a/tests/unit/plugins/remark/html-comments.unit.test.ts
+++ b/tests/unit/plugins/remark/html-comments.unit.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for HTML comment preservation in remark processing
+ *
+ * IMPORTANT: This test documents an architectural inconsistency related to Issue #119
+ * (https://github.com/Digital-Lawyers/legal-markdown-js/issues/119)
+ *
+ * Current behavior:
+ * - Direct remark processing: HTML comments are PRESERVED ✅
+ * - Imported content: HTML comments are STRIPPED (workaround in imports.ts) ❌
+ *
+ * When Issue #119 is resolved (remarkImports inserts AST instead of text), the
+ * stripHtmlComments() workaround should be removed and ALL comments should be preserved.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkStringify from 'remark-stringify';
+import { remarkLegalHeadersParser } from '../../../../src/plugins/remark/legal-headers-parser';
+import { remarkImports } from '../../../../src/plugins/remark/imports';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+describe('HTML Comments Preservation - Direct Processing', () => {
+  it('should preserve HTML comments when processing legal headers', () => {
+    const input = `<!-- This is a comment -->
+
+ll. - Section Title
+
+Some content here.
+
+<!-- Another comment -->`;
+
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkLegalHeadersParser)
+      .use(remarkStringify);
+
+    const result = processor.processSync(input);
+    const output = String(result);
+
+    // Comments should be preserved as HTML comments, not escaped
+    expect(output).toContain('<!-- This is a comment -->');
+    expect(output).toContain('<!-- Another comment -->');
+    expect(output).not.toContain('&lt;!--');
+    expect(output).not.toContain('--&gt;');
+  });
+
+  it('should preserve HTML comments in complex documents', () => {
+    const input = `<!-- Header comment -->
+ll. - First Section
+
+Content for first section.
+
+<!-- Middle comment -->
+lll. Subsection
+
+Subsection content.
+
+<!-- Footer comment -->`;
+
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkLegalHeadersParser)
+      .use(remarkStringify);
+
+    const result = processor.processSync(input);
+    const output = String(result);
+
+    // All comments should be preserved
+    expect(output).toContain('<!-- Header comment -->');
+    expect(output).toContain('<!-- Middle comment -->');
+    expect(output).toContain('<!-- Footer comment -->');
+
+    // Headers should still be converted
+    expect(output).toContain('##');
+    expect(output).toContain('###');
+  });
+
+  it('should handle comments inline with text', () => {
+    const input = `ll. - Section <!-- inline comment --> Title
+
+Content here.`;
+
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkLegalHeadersParser)
+      .use(remarkStringify);
+
+    const result = processor.processSync(input);
+    const output = String(result);
+
+    // Inline comments should be preserved
+    expect(output).toContain('<!-- inline comment -->');
+    expect(output).not.toContain('&lt;!--');
+  });
+});
+
+describe('HTML Comments Preservation - Imported Content (Issue #119 Workaround)', () => {
+  /**
+   * These tests document the CURRENT workaround behavior where HTML comments
+   * are stripped from imported content to prevent remarkStringify escaping issues.
+   *
+   * TODO: When Issue #119 is resolved, these tests should FAIL and be updated
+   * to verify that comments ARE preserved in imported content.
+   */
+
+  it('should strip HTML comments from imported files (current workaround)', () => {
+    // Create temporary directory and files
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'html-comments-test-'));
+    const importedFile = path.join(tempDir, 'imported.md');
+    const mainFile = path.join(tempDir, 'main.md');
+
+    try {
+      // Create imported file with HTML comments and legal headers
+      fs.writeFileSync(
+        importedFile,
+        `<!-- Comment before header -->
+ll. - Imported Section
+<!-- Comment after header -->
+
+Content from imported file.
+
+<!-- Footer comment -->`
+      );
+
+      // Create main file that imports the file with comments
+      fs.writeFileSync(
+        mainFile,
+        `# Main Document
+
+@import imported.md`
+      );
+
+      // Process with remarkImports
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkImports, { basePath: tempDir })
+        .use(remarkLegalHeadersParser)
+        .use(remarkStringify);
+
+      const mainContent = fs.readFileSync(mainFile, 'utf-8');
+      const result = processor.processSync(mainContent);
+      const output = String(result);
+
+      // CURRENT BEHAVIOR (workaround): Comments should be STRIPPED from imported content
+      expect(output).not.toContain('<!-- Comment before header -->');
+      expect(output).not.toContain('<!-- Comment after header -->');
+      expect(output).not.toContain('<!-- Footer comment -->');
+
+      // But headers should still be converted
+      expect(output).toContain('##');
+      expect(output).toContain('Imported Section');
+
+      // TODO: When Issue #119 is resolved, update this test to verify comments ARE preserved:
+      // expect(output).toContain('<!-- Comment before header -->');
+      // expect(output).toContain('<!-- Comment after header -->');
+      // expect(output).toContain('<!-- Footer comment -->');
+    } finally {
+      // Cleanup
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should document the inconsistency: direct content preserves comments, imported content strips them', () => {
+    // Create temporary directory and files
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'html-comments-test-'));
+    const importedFile = path.join(tempDir, 'imported.md');
+    const mainFile = path.join(tempDir, 'main.md');
+
+    try {
+      // Imported file with comment
+      fs.writeFileSync(
+        importedFile,
+        `<!-- Imported comment -->
+ll. - Imported Section`
+      );
+
+      // Main file with direct comment AND import
+      fs.writeFileSync(
+        mainFile,
+        `<!-- Direct comment -->
+ll. - Direct Section
+
+@import imported.md`
+      );
+
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkImports, { basePath: tempDir })
+        .use(remarkLegalHeadersParser)
+        .use(remarkStringify);
+
+      const mainContent = fs.readFileSync(mainFile, 'utf-8');
+      const result = processor.processSync(mainContent);
+      const output = String(result);
+
+      // INCONSISTENCY: Direct comment preserved, imported comment stripped
+      expect(output).toContain('<!-- Direct comment -->'); // ✅ Preserved
+      expect(output).not.toContain('<!-- Imported comment -->'); // ❌ Stripped (workaround)
+
+      // TODO: When Issue #119 is resolved, both should be preserved:
+      // expect(output).toContain('<!-- Direct comment -->');
+      // expect(output).toContain('<!-- Imported comment -->');
+    } finally {
+      // Cleanup
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes multiple issues with imported file processing related to Issue #119:
- Headers in imported files (ll., lll., etc.) were not being converted to markdown headers
- Mixins defined in imported file frontmatter were not being expanded
- Formula highlighting was incorrect (showing blue instead of yellow)
- HTML structural tags were being escaped incorrectly in output

## Changes

### Plugin Order Fix
- Reordered plugins so `remarkImports` runs before `remarkLegalHeadersParser`
- Added extensive documentation about critical plugin execution order
- Prevents headers in imported files from being left unconverted

### Mixin Expansion Enhancement
- Added `accumulatedMetadata` to track metadata from all imported files
- Created `expandMixinsWithTracking()` function that:
  - Expands mixins using accumulated metadata
  - Wraps results in HTML spans for field tracking
  - Detects formulas vs simple fields for correct CSS classes:
    - Formulas (functions, conditionals): `legal-field highlight` (yellow)
    - Simple fields: `legal-field imported-value` (blue)
  - Only expands mixins found in imported metadata

### HTML Escaping Fixes
- Added preprocessing to unescape backslash-escaped HTML from remarkStringify
- Added `unescapeStructuralTags()` for page-break divs
- Ensures structural elements render correctly in HTML and PDF

### Test Coverage
- Added integration test for headers in imported files
- Added unit tests documenting HTML comment behavior:
  - Direct processing: comments preserved (expected)
  - Imported content: comments stripped (workaround for #119)
- Tests include TODO comments for future architectural fixes

## Related Issues

This PR implements workarounds for Issue #119 (remarkImports inserts text instead of AST). All changes are documented as temporary solutions until the root cause is resolved.

## Test Plan

- [x] All new tests pass (8/8)
- [x] Integration test validates headers are converted in imported files
- [x] Unit tests document current HTML comment behavior
- [x] Mixin expansion works correctly with field tracking
- [x] Formula highlighting shows correct colors (yellow for logic)
- [x] Page breaks render correctly in both HTML and PDF output