### PR TITLE
feat: add version display in PDF footers and fix header/footer regression

### DIFF
--- a/src/core/pipeline/format-generator.ts
+++ b/src/core/pipeline/format-generator.ts
@@ -410,10 +410,14 @@ async function generatePdfFormats(
     metadata: processedResult.metadata,
   };
 
+  // Extract version from metadata for PDF footer
+  const version = processedResult.metadata?.version;
+
   const pdfGeneratorOptions = {
     format: options.format,
     landscape: options.landscape,
-    // Note: CSS options are not needed here since HTML is pre-generated with CSS already applied
+    version, // For footer display
+    cssPath: options.cssPath, // Needed for logo detection
   };
 
   if (options.highlight) {

--- a/src/extensions/generators/pdf-templates.ts
+++ b/src/extensions/generators/pdf-templates.ts
@@ -47,16 +47,16 @@ export class PdfTemplates {
 
     return `
       <div style="
-        width: 100%; 
-        font-size: ${PDF_TEMPLATE_CONSTANTS.FONT_SIZE}; 
-        padding-right: ${PDF_TEMPLATE_CONSTANTS.HEADER_PADDING}; 
-        display: flex; 
+        width: 100%;
+        font-size: ${PDF_TEMPLATE_CONSTANTS.FONT_SIZE};
+        padding-right: ${PDF_TEMPLATE_CONSTANTS.HEADER_PADDING};
+        display: flex;
         justify-content: flex-end;
         font-family: ${PDF_TEMPLATE_CONSTANTS.FONT_FAMILY};
       ">
-        <img 
-          src="data:image/png;base64,${logoBase64}" 
-          style="height: ${PDF_TEMPLATE_CONSTANTS.LOGO_HEIGHT};" 
+        <img
+          src="data:image/png;base64,${logoBase64}"
+          style="height: ${PDF_TEMPLATE_CONSTANTS.LOGO_HEIGHT};"
           alt="Logo"
         />
       </div>
@@ -64,27 +64,52 @@ export class PdfTemplates {
   }
 
   /**
-   * Generates HTML template for PDF footers with page numbers
+   * Generates HTML template for PDF footers with page numbers and optional version
    *
-   * Creates a right-aligned footer with "Page X / Y" format using Puppeteer's
-   * special classes for dynamic page numbering.
+   * Creates a footer with page numbers on the right. If a version is provided,
+   * it displays on the left in a smaller font.
    *
+   * @param {string} [version] - Optional version string from frontmatter metadata
    * @returns {string} HTML template string for the footer
    * @example
    * ```typescript
-   * const footer = PdfTemplates.generateFooterTemplate();
-   * // Results in: "Pg: 1 / 10" format in the PDF
+   * // Footer with version
+   * const footer = PdfTemplates.generateFooterTemplate('1.2.0');
+   * // Results in: "v1.2.0" (left) and "Pg: 1 / 10" (right)
+   *
+   * // Footer without version (backward compatible)
+   * const simpleFooter = PdfTemplates.generateFooterTemplate();
+   * // Results in: "Pg: 1 / 10" (right-aligned)
    * ```
    */
-  static generateFooterTemplate(): string {
+  static generateFooterTemplate(version?: string): string {
+    if (!version) {
+      // Backward compatible: no version, right-aligned page numbers only
+      return `
+        <div style="
+          width: 100%;
+          font-size: ${PDF_TEMPLATE_CONSTANTS.FONT_SIZE};
+          padding: 10px ${PDF_TEMPLATE_CONSTANTS.FOOTER_PADDING};
+          text-align: right;
+          font-family: ${PDF_TEMPLATE_CONSTANTS.FONT_FAMILY};
+        ">
+          <span>Pg: <span class="pageNumber"></span> / <span class="totalPages"></span></span>
+        </div>
+      `.trim();
+    }
+
+    // With version: version on left (small), page numbers on right
     return `
       <div style="
-        width: 100%; 
-        font-size: ${PDF_TEMPLATE_CONSTANTS.FONT_SIZE}; 
-        padding: 10px ${PDF_TEMPLATE_CONSTANTS.FOOTER_PADDING}; 
-        text-align: right; 
+        width: 100%;
+        font-size: ${PDF_TEMPLATE_CONSTANTS.FONT_SIZE};
+        padding: 10px ${PDF_TEMPLATE_CONSTANTS.FOOTER_PADDING};
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
         font-family: ${PDF_TEMPLATE_CONSTANTS.FONT_FAMILY};
       ">
+        <span style="font-size: 8px; color: #666;">v${version}</span>
         <span>Pg: <span class="pageNumber"></span> / <span class="totalPages"></span></span>
       </div>
     `.trim();


### PR DESCRIPTION
## Summary

Implements version display in PDF footers from frontmatter metadata and fixes critical regression where headers/footers were missing after the 3-phase pipeline refactor.

### Key Changes

**Version Display Feature:**
- Extract `version` from frontmatter metadata in Phase 3
- Display `v{version}` on left side of PDF footer (8px, gray text)
- Page numbers remain on right side
- Backward compatible: footers without version maintain original right-aligned format

**Regression Fix:**
- Restored header/footer auto-generation logic in `generatePdfFromHtml()`
- Added logo detection from CSS in `generatePdfFromHtml()`
- Pass `cssPath` to PDF generator options for logo detection
- Increased margins to 3cm (top/bottom) to prevent content cutoff

### Root Cause

The regression occurred when PR #132 refactored the pipeline to use `generatePdfFromHtml()` instead of `generatePdf()`. The new method was missing the auto-generation logic for headers/footers (lines 830-857 in the original `generatePdf()` method), causing PDFs to be generated without headers/footers even when CSS contained logo definitions.

### Technical Details

**Files Modified:**
- `src/core/pipeline/format-generator.ts`: Extract version from metadata and pass to PDF options
- `src/extensions/generators/pdf-generator.ts`: Add `version` option, restore header/footer logic in `generatePdfFromHtml()`
- `src/extensions/generators/pdf-templates.ts`: Update `generateFooterTemplate()` to accept optional version parameter

**Template Changes:**
- Footer without version: `<div style="text-align: right;">Pg: X / Y</div>`
- Footer with version: `<div style="display: flex; justify-content: space-between;"><span>v1.2.3</span><span>Pg: X / Y</span></div>`

### Test Plan

- [x] Generate PDF without version in frontmatter → footer shows only page numbers (right-aligned)
- [x] Generate PDF with `version: 1.2.3` in frontmatter → footer shows "v1.2.3" (left) + "Pg: X / Y" (right)
- [x] Generate PDF with CSS containing logo → header shows logo
- [x] Verify margins prevent content cutoff at bottom of page
- [x] All existing tests pass (staged tests verified via lint-staged)

### Related

Implements steps 1-4 from `docs/pdf-footer-version-notes.md`

Fixes regression introduced in PR #132 (3-phase pipeline refactor)