### PR TITLE
feat: add .docx and .pdf download buttons to playground toolbar

### DIFF
--- a/docs/plans/2026-03-06-export-formats-playground-design.md
+++ b/docs/plans/2026-03-06-export-formats-playground-design.md
@@ -1,0 +1,77 @@
+# Design: Export Format Buttons in Playground (DOCX + PDF)
+
+## Context
+
+The playground UI has three resizable columns:
+
+1. Legal MD editor (`EditorPanel`)
+2. CSS editor (`CSSEditorPanel`)
+3. Preview/output panel - toolbar + `PreviewPanel` tabs
+
+The third column toolbar currently has: Process, Download (HTML/MD), Copy,
+Print, Options, Metadata.
+
+The request is to add dedicated `.pdf` and `.docx` download buttons with a
+download icon.
+
+## Decision
+
+### DOCX
+
+Use the project's own `DocxGenerator` pipeline - the same one used by the CLI
+(`--docx` flag). Quality was validated against the `office-lease-complete`
+example and confirmed good.
+
+The generator currently requires `fs` to read CSS from disk and write the output
+file. For the browser, we add a `generateDocxBuffer(html, css, options)` method
+that:
+
+- Accepts CSS as a string (no file read)
+- Returns a `Buffer` / `Uint8Array` instead of writing to disk
+- Uses the same internal `convertHtmlToDocxBlocks` + `docx` (Packer) logic
+
+This method gets exposed via the browser bundle
+(`window.LegalMarkdown.generateDocxBuffer`).
+
+In the playground, `useLegalMarkdown` gets a `downloadDocx()` helper that:
+
+1. Calls
+   `window.LegalMarkdown.generateDocxBuffer(bodyHtml, customCSS, { title })`
+2. Creates a `Blob` with DOCX MIME type
+3. Triggers download via `URL.createObjectURL`
+
+### PDF
+
+Reuse the existing `printDocument` logic surfaced as a dedicated button. The
+browser print dialog allows saving as PDF. No server or Puppeteer required. A
+`@media print` stylesheet is already applied via the CSS editor.
+
+## UI
+
+Two buttons added to the third column toolbar, after the existing Print button:
+
+```
+[ Play Process ] | [ Download ] Copy HTML [ Print ] [ .docx ] [ .pdf ] | Options | Metadata
+```
+
+- Both use `lucide-react`'s `Download` icon + label text (`.docx` / `.pdf`)
+- Style: `ghost`, `sm`, same as existing Copy button
+- Disabled when `result` is null
+- Tooltip on hover
+- Loading state on `.docx` button while buffer is generating (async)
+
+## Files to Change
+
+| File                                          | Change                                                   |
+| --------------------------------------------- | -------------------------------------------------------- |
+| `src/extensions/generators/docx-generator.ts` | Add `generateDocxBuffer()` method                        |
+| `src/web/src/types/legal-markdown.d.ts`       | Add `generateDocxBuffer` to `LegalMarkdownLib` interface |
+| `src/web/public/legal-markdown-loader.js`     | Expose `generateDocxBuffer` from the bundle              |
+| `src/web/src/hooks/useLegalMarkdown.ts`       | Add `downloadDocx()` to the hook return                  |
+| `src/web/src/App.tsx`                         | Add the two buttons to the toolbar                       |
+
+## Out of Scope
+
+- Server-side generation
+- PDF via Puppeteer in the browser
+- DOCX highlight variant (only normal version for now)

--- a/docs/plans/2026-03-06-export-formats-playground.md
+++ b/docs/plans/2026-03-06-export-formats-playground.md
@@ -1,0 +1,483 @@
+# Export Format Buttons (DOCX + PDF) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to
+> implement this plan task-by-task.
+
+**Goal:** Add `.docx` and `.pdf` download buttons to the third column toolbar of
+the playground UI.
+
+**Architecture:** A new browser-safe `generateDocxBuffer(html, css, options)`
+function is added to `src/extensions/generators/docx-browser.ts`, exported from
+the browser entry point (`src/browser-modern.ts`), and exposed on
+`window.LegalMarkdown`. The playground hook gets a `downloadDocx()` helper; the
+`.pdf` button reuses the existing `printDocument` flow. The bundle is rebuilt
+after each change to `browser-modern.ts`.
+
+**Tech Stack:** React, TypeScript, `docx` npm package (Packer -
+browser-compatible), Vite (browser bundle), lucide-react icons, Tailwind CSS.
+
+---
+
+### Task 1: Create browser-safe `generateDocxBuffer`
+
+**Files:**
+
+- Create: `src/extensions/generators/docx-browser.ts`
+
+**Context:** `DocxGenerator.generateDocxFromHtml` cannot run in the browser
+because it calls `fs.mkdir`, `fs.readFile` (for CSS), and `fs.writeFile`. Those
+are shimmed to throw in the browser bundle. The sub-modules it depends on
+(`adaptCssToDocxStyles`, `convertHtmlToDocxBlocks`, `docx` `Packer`) are all
+browser-compatible. We create a thin, `fs`-free wrapper around them.
+
+**Step 1: Create the file**
+
+```typescript
+// src/extensions/generators/docx-browser.ts
+import {
+  AlignmentType,
+  Document,
+  Footer,
+  Header,
+  PageNumber,
+  PageOrientation,
+  Packer,
+  Paragraph,
+  TextRun,
+  type IPageMarginAttributes,
+  type IPageSizeAttributes,
+} from 'docx';
+import { adaptCssToDocxStyles } from './docx/css-style-adapter';
+import {
+  convertHtmlToDocxBlocks,
+  createDefaultNumbering,
+} from './docx/html-to-docx';
+
+const PAGE_SIZES: Record<
+  'A4' | 'Letter' | 'Legal',
+  { width: number; height: number }
+> = {
+  A4: { width: 11906, height: 16838 },
+  Letter: { width: 12240, height: 15840 },
+  Legal: { width: 12240, height: 20160 },
+};
+
+export interface DocxBrowserOptions {
+  title?: string;
+  format?: 'A4' | 'Letter' | 'Legal';
+  landscape?: boolean;
+}
+
+/**
+ * Generate a DOCX buffer from HTML and CSS strings - browser-safe.
+ *
+ * Does not touch the filesystem. CSS is accepted as a string instead
+ * of a file path. Returns a Uint8Array that can be wrapped in a Blob
+ * and downloaded via URL.createObjectURL.
+ */
+export async function generateDocxBuffer(
+  html: string,
+  css: string,
+  options: DocxBrowserOptions = {}
+): Promise<Uint8Array> {
+  const stylePreset = adaptCssToDocxStyles(css);
+
+  const blocks = await convertHtmlToDocxBlocks(html, {
+    styles: stylePreset,
+    includeHighlighting: false,
+    basePath: '',
+  });
+
+  const header = new Header({
+    children: [new Paragraph({ children: [new TextRun('')] })],
+  });
+
+  const footer = new Footer({
+    children: [
+      new Paragraph({
+        alignment: AlignmentType.RIGHT,
+        children: [
+          new TextRun('Pg: '),
+          new TextRun({ children: [PageNumber.CURRENT] }),
+          new TextRun(' / '),
+          new TextRun({ children: [PageNumber.TOTAL_PAGES] }),
+        ],
+      }),
+    ],
+  });
+
+  const selectedFormat = options.format ?? 'A4';
+  const pageDims = PAGE_SIZES[selectedFormat] ?? PAGE_SIZES.A4;
+  const size: IPageSizeAttributes = options.landscape
+    ? {
+        width: pageDims.height,
+        height: pageDims.width,
+        orientation: PageOrientation.LANDSCAPE,
+      }
+    : {
+        width: pageDims.width,
+        height: pageDims.height,
+        orientation: PageOrientation.PORTRAIT,
+      };
+
+  const margins: IPageMarginAttributes = {
+    top: 1440,
+    right: 1440,
+    bottom: 1440,
+    left: 1440,
+    header: 720,
+    footer: 720,
+    gutter: 0,
+  };
+
+  const document = new Document({
+    title: options.title,
+    description: options.title,
+    styles: stylePreset.styles,
+    numbering: createDefaultNumbering(stylePreset),
+    sections: [
+      {
+        properties: { page: { size, margin: margins } },
+        headers: { default: header },
+        footers: { default: footer },
+        children: blocks,
+      },
+    ],
+  });
+
+  return Packer.toBuffer(document);
+}
+```
+
+**Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit 2>&1 | grep docx-browser
+```
+
+Expected: no output (no errors).
+
+**Step 3: Commit**
+
+```bash
+git add src/extensions/generators/docx-browser.ts
+git commit -m "feat: add browser-safe generateDocxBuffer function"
+```
+
+---
+
+### Task 2: Export from the browser bundle entry point
+
+**Files:**
+
+- Modify: `src/browser-modern.ts`
+
+**Context:** `src/browser-modern.ts` is the entry point for
+`dist/legal-markdown-browser.js`. Anything added to the default export object
+and re-exported as a named export becomes available on `window.LegalMarkdown` in
+the playground.
+
+**Step 1: Add import and export**
+
+At the top of `src/browser-modern.ts`, after the existing imports, add:
+
+```typescript
+import { generateDocxBuffer } from './extensions/generators/docx-browser';
+export type { DocxBrowserOptions } from './extensions/generators/docx-browser';
+export { generateDocxBuffer };
+```
+
+Then add `generateDocxBuffer` to the `LegalMarkdown` default export object:
+
+```typescript
+const LegalMarkdown = {
+  processLegalMarkdownAsync,
+  processLegalMarkdown,
+  process: processLegalMarkdownAsync,
+  markdownToHtmlBody,
+  formatHtml,
+  wrapHtmlDocument,
+  generateDocxBuffer, // <-- add this line
+  version: __LEGAL_MARKDOWN_VERSION__,
+  isModernBundle: true,
+};
+```
+
+**Step 2: Rebuild the browser bundle**
+
+```bash
+npm run build:vite && node scripts/copy-web-bundle.js
+```
+
+Expected: `Copied legal-markdown-browser.js -> src/web/public/` (plus any chunk
+files).
+
+**Step 3: Verify the export is present in the bundle**
+
+```bash
+grep -c "generateDocxBuffer" src/web/public/legal-markdown-browser.js
+```
+
+Expected: a number greater than 0.
+
+**Step 4: Commit**
+
+```bash
+git add src/browser-modern.ts src/web/public/
+git commit -m "feat: expose generateDocxBuffer in browser bundle"
+```
+
+---
+
+### Task 3: Update the TypeScript interface for the browser library
+
+**Files:**
+
+- Modify: `src/web/src/types/legal-markdown.d.ts`
+
+**Context:** The playground is a separate Vite app. It declares
+`window.LegalMarkdown` via this `.d.ts` file. Without updating it, TypeScript
+will complain when we call `window.LegalMarkdown.generateDocxBuffer(...)`.
+
+**Step 1: Add the method signature**
+
+In `src/web/src/types/legal-markdown.d.ts`, inside `LegalMarkdownLib`, add after
+`wrapHtmlDocument`:
+
+```typescript
+/** Generate a DOCX buffer from HTML body and CSS strings - browser-safe */
+generateDocxBuffer(
+  html: string,
+  css: string,
+  options?: { title?: string; format?: 'A4' | 'Letter' | 'Legal'; landscape?: boolean }
+): Promise<Uint8Array>;
+```
+
+**Step 2: Verify TypeScript is happy**
+
+```bash
+cd src/web && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no errors mentioning `generateDocxBuffer`.
+
+**Step 3: Commit**
+
+```bash
+git add src/web/src/types/legal-markdown.d.ts
+git commit -m "feat: add generateDocxBuffer to LegalMarkdownLib type"
+```
+
+---
+
+### Task 4: Add `downloadDocx` to the hook
+
+**Files:**
+
+- Modify: `src/web/src/hooks/useLegalMarkdown.ts`
+
+**Context:** The hook currently exposes `downloadContent(content, filename)` for
+text-based formats. DOCX is binary, so we need a dedicated helper. The
+`bodyHtml` and `customCSS` live in `App.tsx` (derived from `result` and
+`customCSS`), so `downloadDocx` needs to receive them as arguments - or we pass
+them through from `App.tsx` at call time. The cleanest approach: expose a
+`downloadDocx(html, css, title)` function from the hook that handles the Blob
+creation and download trigger.
+
+**Step 1: Add `downloadDocx` to the interface**
+
+In `UseLegalMarkdownReturn` (around line 23), add:
+
+```typescript
+downloadDocx: (html: string, css: string, title: string) => Promise<void>;
+```
+
+**Step 2: Implement `downloadDocx`**
+
+After the existing `downloadContent` implementation (around line 99), add:
+
+```typescript
+const downloadDocx = useCallback(
+  async (html: string, css: string, title: string) => {
+    const buffer = await window.LegalMarkdown.generateDocxBuffer(html, css, {
+      title,
+    });
+    const blob = new Blob([buffer], {
+      type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${title.replace(/[^a-zA-Z0-9]/g, '-')}.docx`;
+    a.click();
+    URL.revokeObjectURL(url);
+  },
+  []
+);
+```
+
+**Step 3: Add to the return object**
+
+In the `return { ... }` at the bottom of `useLegalMarkdown`, add `downloadDocx`.
+
+**Step 4: Verify TypeScript**
+
+```bash
+cd src/web && npx tsc --noEmit 2>&1 | grep -i docx
+```
+
+Expected: no output.
+
+**Step 5: Commit**
+
+```bash
+git add src/web/src/hooks/useLegalMarkdown.ts
+git commit -m "feat: add downloadDocx helper to useLegalMarkdown hook"
+```
+
+---
+
+### Task 5: Add the two buttons to the toolbar
+
+**Files:**
+
+- Modify: `src/web/src/App.tsx`
+
+**Context:** The third column toolbar (lines 241-284 in `App.tsx`) already has
+an `IconButton` component. We need two new buttons after the existing print
+button:
+
+- `.docx` - triggers `downloadDocx(bodyHtml, css, title)` with a loading state
+- `.pdf` - triggers `printDocument()` (existing), just relabeled
+
+Both are ghost buttons with a `Download` icon and text label. The `Download`
+icon is already imported.
+
+**Step 1: Add `isDocxLoading` state**
+
+After the existing `useState` calls (around line 73), add:
+
+```typescript
+const [isDocxLoading, setIsDocxLoading] = useState(false);
+```
+
+**Step 2: Add `handleDownloadDocx` handler**
+
+After `handleCopy` (around line 120), add:
+
+```typescript
+const handleDownloadDocx = useCallback(async () => {
+  if (!result || !bodyHtml) return;
+  setIsDocxLoading(true);
+  try {
+    const title = (result.metadata?.title as string) || 'legal-document';
+    const effectiveCss = ensureHighlightCss(
+      customCSS,
+      Boolean(options.enableFieldTracking)
+    );
+    await downloadDocx(bodyHtml, effectiveCss, title);
+  } catch (err) {
+    toast.error('DOCX generation failed', {
+      description: err instanceof Error ? err.message : String(err),
+    });
+  } finally {
+    setIsDocxLoading(false);
+  }
+}, [result, bodyHtml, customCSS, options.enableFieldTracking, downloadDocx]);
+```
+
+Note: `toast` is already available from `sonner` via the hook - but `App.tsx`
+doesn't import it directly. Import it at the top:
+
+```typescript
+import { toast } from 'sonner';
+```
+
+**Step 3: Destructure `downloadDocx` from the hook**
+
+In the `useLegalMarkdown()` destructure (around line 57), add `downloadDocx`:
+
+```typescript
+const { ...downloadDocx } = useLegalMarkdown();
+```
+
+**Step 4: Add the two buttons to the toolbar JSX**
+
+After the existing print `IconButton` (around line 268), and before the
+`Options` separator, add:
+
+```tsx
+<Separator orientation="vertical" className="h-5 bg-slate-700 mx-0.5" />
+<Button
+  variant="ghost"
+  size="sm"
+  onClick={handleDownloadDocx}
+  disabled={!result || isDocxLoading}
+  className="h-7 text-xs cursor-pointer text-slate-300 hover:text-slate-100 px-2"
+>
+  <Download className="h-3.5 w-3.5 mr-1" />
+  {isDocxLoading ? '...' : '.docx'}
+</Button>
+<Button
+  variant="ghost"
+  size="sm"
+  onClick={printDocument}
+  disabled={!result}
+  className="h-7 text-xs cursor-pointer text-slate-300 hover:text-slate-100 px-2"
+>
+  <Download className="h-3.5 w-3.5 mr-1" />
+  .pdf
+</Button>
+```
+
+**Step 5: Verify TypeScript**
+
+```bash
+cd src/web && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no errors.
+
+**Step 6: Commit**
+
+```bash
+git add src/web/src/App.tsx
+git commit -m "feat: add .docx and .pdf download buttons to playground toolbar"
+```
+
+---
+
+### Task 6: Build and smoke-test in the browser
+
+**Step 1: Build the web app**
+
+```bash
+npm run build:web
+```
+
+Expected: build completes with no errors.
+
+**Step 2: Start dev server and open browser**
+
+```bash
+npm run dev:web
+```
+
+Open the playground and:
+
+1. Load an example (e.g. "Master Services Agreement")
+2. Click **Process**
+3. Click **.docx** - Word should open a valid document
+4. Click **.pdf** - browser print dialog should appear
+
+**Step 3: Verify no console errors**
+
+Open DevTools → Console. Expected: no errors related to `generateDocxBuffer` or
+`fs`.
+
+**Step 4: Final commit if anything was fixed**
+
+```bash
+git add -p
+git commit -m "fix: address any smoke-test issues"
+```

--- a/src/browser-modern.ts
+++ b/src/browser-modern.ts
@@ -35,6 +35,10 @@ import {
 // Import shared HTML formatting utilities (browser-compatible)
 import { markdownToHtmlBody, formatHtml, wrapHtmlDocument } from './utils/html-format';
 
+import { generateDocxBuffer } from './extensions/generators/docx-browser';
+export type { DocxBrowserOptions } from './extensions/generators/docx-browser';
+export { generateDocxBuffer };
+
 declare const __LEGAL_MARKDOWN_VERSION__: string;
 
 // Re-export the types for convenience
@@ -85,6 +89,7 @@ const LegalMarkdown = {
   markdownToHtmlBody,
   formatHtml,
   wrapHtmlDocument,
+  generateDocxBuffer,
 
   // Version info
   version: __LEGAL_MARKDOWN_VERSION__,

--- a/src/extensions/generators/docx-browser.ts
+++ b/src/extensions/generators/docx-browser.ts
@@ -1,0 +1,99 @@
+import {
+  AlignmentType,
+  Document,
+  Footer,
+  Header,
+  PageNumber,
+  PageOrientation,
+  Packer,
+  Paragraph,
+  TextRun,
+  type IPageMarginAttributes,
+  type IPageSizeAttributes,
+} from 'docx';
+import { adaptCssToDocxStyles } from './docx/css-style-adapter';
+import { convertHtmlToDocxBlocks, createDefaultNumbering } from './docx/html-to-docx';
+
+const PAGE_SIZES: Record<'A4' | 'Letter' | 'Legal', { width: number; height: number }> = {
+  A4: { width: 11906, height: 16838 },
+  Letter: { width: 12240, height: 15840 },
+  Legal: { width: 12240, height: 20160 },
+};
+
+export interface DocxBrowserOptions {
+  title?: string;
+  format?: 'A4' | 'Letter' | 'Legal';
+  landscape?: boolean;
+}
+
+/**
+ * Generate a DOCX buffer from HTML and CSS strings - browser-safe.
+ *
+ * Does not touch the filesystem. CSS is accepted as a string instead
+ * of a file path. Returns a Uint8Array that can be wrapped in a Blob
+ * and downloaded via URL.createObjectURL.
+ */
+export async function generateDocxBuffer(
+  html: string,
+  css: string,
+  options: DocxBrowserOptions = {}
+): Promise<Uint8Array> {
+  const stylePreset = adaptCssToDocxStyles(css);
+
+  const blocks = await convertHtmlToDocxBlocks(html, {
+    styles: stylePreset,
+    includeHighlighting: false,
+    basePath: '',
+  });
+
+  const header = new Header({
+    children: [new Paragraph({ children: [new TextRun('')] })],
+  });
+
+  const footer = new Footer({
+    children: [
+      new Paragraph({
+        alignment: AlignmentType.RIGHT,
+        children: [
+          new TextRun('Pg: '),
+          new TextRun({ children: [PageNumber.CURRENT] }),
+          new TextRun(' / '),
+          new TextRun({ children: [PageNumber.TOTAL_PAGES] }),
+        ],
+      }),
+    ],
+  });
+
+  const selectedFormat = options.format ?? 'A4';
+  const pageDims = PAGE_SIZES[selectedFormat] ?? PAGE_SIZES.A4;
+  const size: IPageSizeAttributes = options.landscape
+    ? { width: pageDims.height, height: pageDims.width, orientation: PageOrientation.LANDSCAPE }
+    : { width: pageDims.width, height: pageDims.height, orientation: PageOrientation.PORTRAIT };
+
+  const margins: IPageMarginAttributes = {
+    top: 1440,
+    right: 1440,
+    bottom: 1440,
+    left: 1440,
+    header: 720,
+    footer: 720,
+    gutter: 0,
+  };
+
+  const document = new Document({
+    title: options.title,
+    description: options.title,
+    styles: stylePreset.styles,
+    numbering: createDefaultNumbering(stylePreset),
+    sections: [
+      {
+        properties: { page: { size, margin: margins } },
+        headers: { default: header },
+        footers: { default: footer },
+        children: blocks,
+      },
+    ],
+  });
+
+  return Packer.toBuffer(document);
+}

--- a/src/extensions/generators/docx-browser.ts
+++ b/src/extensions/generators/docx-browser.ts
@@ -27,17 +27,17 @@ export interface DocxBrowserOptions {
 }
 
 /**
- * Generate a DOCX buffer from HTML and CSS strings - browser-safe.
+ * Generate a DOCX Blob from HTML and CSS strings - browser-safe.
  *
  * Does not touch the filesystem. CSS is accepted as a string instead
- * of a file path. Returns a Uint8Array that can be wrapped in a Blob
- * and downloaded via URL.createObjectURL.
+ * of a file path. Returns a Blob that can be downloaded directly via
+ * URL.createObjectURL.
  */
 export async function generateDocxBuffer(
   html: string,
   css: string,
   options: DocxBrowserOptions = {}
-): Promise<Uint8Array> {
+): Promise<Blob> {
   const stylePreset = adaptCssToDocxStyles(css);
 
   const blocks = await convertHtmlToDocxBlocks(html, {
@@ -95,5 +95,13 @@ export async function generateDocxBuffer(
     ],
   });
 
-  return Packer.toBuffer(document);
+  const base64 = await Packer.toBase64String(document);
+  const binaryStr = atob(base64);
+  const bytes = new Uint8Array(binaryStr.length);
+  for (let i = 0; i < binaryStr.length; i++) {
+    bytes[i] = binaryStr.charCodeAt(i);
+  }
+  return new Blob([bytes], {
+    type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  });
 }

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import { Scale, Play, Download, Printer, BarChart2 } from 'lucide-react';
+import { toast } from 'sonner';
 import { TooltipProvider, Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Toaster } from '@/components/ui/sonner';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
@@ -66,12 +67,14 @@ export default function App() {
     error,
     processNow,
     downloadContent,
+    downloadDocx,
     printDocument,
     copyContent,
   } = useLegalMarkdown();
 
   const [metadataOpen, setMetadataOpen] = useState(false);
   const [currentCSSPresetKey, setCurrentCSSPresetKey] = useState(DEFAULT_CSS_KEY);
+  const [isDocxLoading, setIsDocxLoading] = useState(false);
   const [activeTab, setActiveTab] = useState<'rendered' | 'markdown' | 'html' | 'html-doc'>(
     'rendered'
   );
@@ -118,6 +121,22 @@ export default function App() {
     const { content } = getTabContent();
     if (content) await copyContent(content);
   }, [getTabContent, copyContent]);
+
+  const handleDownloadDocx = useCallback(async () => {
+    if (!result || !bodyHtml) return;
+    setIsDocxLoading(true);
+    try {
+      const title = (result.metadata?.title as string) || 'legal-document';
+      const effectiveCss = ensureHighlightCss(customCSS, Boolean(options.enableFieldTracking));
+      await downloadDocx(bodyHtml, effectiveCss, title);
+    } catch (err) {
+      toast.error('DOCX generation failed', {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setIsDocxLoading(false);
+    }
+  }, [result, bodyHtml, customCSS, options.enableFieldTracking, downloadDocx]);
 
   const handleExampleChange = useCallback(
     (key: string) => {
@@ -268,6 +287,27 @@ export default function App() {
                   <IconButton label="Print document" onClick={printDocument} disabled={!result}>
                     <Printer className="h-4 w-4" />
                   </IconButton>
+                  <Separator orientation="vertical" className="h-5 bg-slate-700 mx-0.5" />
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleDownloadDocx}
+                    disabled={!result || isDocxLoading}
+                    className="h-7 text-xs cursor-pointer text-slate-300 hover:text-slate-100 px-2"
+                  >
+                    <Download className="h-3.5 w-3.5 mr-1" />
+                    {isDocxLoading ? '...' : '.docx'}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={printDocument}
+                    disabled={!result}
+                    className="h-7 text-xs cursor-pointer text-slate-300 hover:text-slate-100 px-2"
+                  >
+                    <Download className="h-3.5 w-3.5 mr-1" />
+                    .pdf
+                  </Button>
                   <Separator orientation="vertical" className="h-5 bg-slate-700 mx-0.5" />
                   <OptionsPopover options={options} onChange={setOptions} />
                   <Separator orientation="vertical" className="h-5 bg-slate-700 mx-0.5" />

--- a/src/web/src/hooks/useLegalMarkdown.ts
+++ b/src/web/src/hooks/useLegalMarkdown.ts
@@ -32,6 +32,7 @@ export interface UseLegalMarkdownReturn {
   error: string | null;
   processNow: () => Promise<void>;
   downloadContent: (content: string, filename: string) => void;
+  downloadDocx: (html: string, css: string, title: string) => Promise<void>;
   printDocument: () => void;
   copyContent: (content: string) => Promise<void>;
 }
@@ -98,6 +99,19 @@ export function useLegalMarkdown(): UseLegalMarkdownReturn {
     URL.revokeObjectURL(url);
   }, []);
 
+  const downloadDocx = useCallback(async (html: string, css: string, title: string) => {
+    const buffer = await window.LegalMarkdown.generateDocxBuffer(html, css, { title });
+    const blob = new Blob([buffer], {
+      type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${title.replace(/[^a-zA-Z0-9]/g, '-')}.docx`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, []);
+
   const printDocument = useCallback(() => {
     if (!result) return;
     const { markdownToHtmlBody, wrapHtmlDocument } = window.LegalMarkdown;
@@ -137,6 +151,7 @@ export function useLegalMarkdown(): UseLegalMarkdownReturn {
     error,
     processNow,
     downloadContent,
+    downloadDocx,
     printDocument,
     copyContent,
   };

--- a/src/web/src/hooks/useLegalMarkdown.ts
+++ b/src/web/src/hooks/useLegalMarkdown.ts
@@ -100,10 +100,7 @@ export function useLegalMarkdown(): UseLegalMarkdownReturn {
   }, []);
 
   const downloadDocx = useCallback(async (html: string, css: string, title: string) => {
-    const buffer = await window.LegalMarkdown.generateDocxBuffer(html, css, { title });
-    const blob = new Blob([buffer as unknown as ArrayBuffer], {
-      type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-    });
+    const blob = await window.LegalMarkdown.generateDocxBuffer(html, css, { title });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;

--- a/src/web/src/hooks/useLegalMarkdown.ts
+++ b/src/web/src/hooks/useLegalMarkdown.ts
@@ -101,7 +101,7 @@ export function useLegalMarkdown(): UseLegalMarkdownReturn {
 
   const downloadDocx = useCallback(async (html: string, css: string, title: string) => {
     const buffer = await window.LegalMarkdown.generateDocxBuffer(html, css, { title });
-    const blob = new Blob([buffer], {
+    const blob = new Blob([buffer as unknown as ArrayBuffer], {
       type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     });
     const url = URL.createObjectURL(blob);

--- a/src/web/src/types/legal-markdown.d.ts
+++ b/src/web/src/types/legal-markdown.d.ts
@@ -59,6 +59,13 @@ export interface LegalMarkdownLib {
 
   /** Wrap HTML body in a complete HTML5 document with embedded CSS */
   wrapHtmlDocument(body: string, css: string, title: string): string;
+
+  /** Generate a DOCX buffer from HTML body and CSS strings - browser-safe */
+  generateDocxBuffer(
+    html: string,
+    css: string,
+    options?: { title?: string; format?: 'A4' | 'Letter' | 'Legal'; landscape?: boolean }
+  ): Promise<Uint8Array>;
 }
 
 declare global {

--- a/src/web/src/types/legal-markdown.d.ts
+++ b/src/web/src/types/legal-markdown.d.ts
@@ -60,12 +60,12 @@ export interface LegalMarkdownLib {
   /** Wrap HTML body in a complete HTML5 document with embedded CSS */
   wrapHtmlDocument(body: string, css: string, title: string): string;
 
-  /** Generate a DOCX buffer from HTML body and CSS strings - browser-safe */
+  /** Generate a DOCX Blob from HTML body and CSS strings - browser-safe */
   generateDocxBuffer(
     html: string,
     css: string,
     options?: { title?: string; format?: 'A4' | 'Letter' | 'Legal'; landscape?: boolean }
-  ): Promise<Uint8Array>;
+  ): Promise<Blob>;
 }
 
 declare global {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,8 +49,8 @@ export default defineConfig({
       '@utils': path.resolve(__dirname, 'src/utils'),
       // Provide browser shims for Node.js modules
       cosmiconfig: path.resolve(__dirname, 'src/utils/cosmiconfig-shim.ts'),
-      fs: path.resolve(__dirname, 'src/utils/browser-shims.ts'),
       'fs/promises': path.resolve(__dirname, 'src/utils/browser-shims.ts'),
+      fs: path.resolve(__dirname, 'src/utils/browser-shims.ts'),
       path: 'path-browserify',
       buffer: 'buffer',
     },


### PR DESCRIPTION
## Summary

- Add browser-safe `generateDocxBuffer(html, css, options)` function that converts processed HTML to a valid DOCX Blob without touching the filesystem
- Expose it on `window.LegalMarkdown` via the browser bundle entry point
- Add `.docx` and `.pdf` download buttons to the playground's 3rd column toolbar

## Key implementation details

- `generateDocxBuffer` uses the project's own `adaptCssToDocxStyles` + `convertHtmlToDocxBlocks` pipeline (same quality as the CLI `--docx` flag)
- Uses `Packer.toBase64String()` for universal browser compatibility (avoids `Packer.toBuffer()` which requires Node's `Buffer` and throws at runtime in the browser)
- Fixed Vite alias ordering: `fs/promises` must appear before `fs` in `resolve.alias` to avoid prefix-match resolution bugs
- `.pdf` button reuses the existing `printDocument` flow (browser print dialog -> Save as PDF)

## Files changed

- `src/extensions/generators/docx-browser.ts` (new) - browser-safe DOCX generator
- `src/browser-modern.ts` - expose `generateDocxBuffer` on `window.LegalMarkdown`
- `vite.config.ts` - fix `fs/promises` alias ordering
- `src/web/src/types/legal-markdown.d.ts` - add `generateDocxBuffer` to `LegalMarkdownLib`
- `src/web/src/hooks/useLegalMarkdown.ts` - add `downloadDocx` helper
- `src/web/src/App.tsx` - add `.docx` and `.pdf` buttons to toolbar

## Test plan

- [x] All 3,462 unit/e2e tests pass (173 test files, 0 failures)
- [x] `.docx` download verified via Playwright: `Master-Services-Agreement.docx` generated with 0 console errors
- [x] `.pdf` button opens browser print dialog as expected