### PR TITLE
fix: route all processing diagnostic output to stderr

### DIFF
--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -463,7 +463,7 @@ export class CliService {
     }
 
     this.log('Files generated successfully!', 'success');
-    console.log(chalk.bold('\n📄 Generated files:'));
+    console.error(chalk.bold('\n📄 Generated files:'));
 
     if (hasHighlight) {
       // Group files by extension
@@ -496,23 +496,23 @@ export class CliService {
       for (const ext of ['md', 'html', 'pdf', 'docx']) {
         if (!extensions.has(ext)) continue;
 
-        console.log(chalk.gray(`\n   ${ext.toUpperCase()}:`));
+        console.error(chalk.gray(`\n   ${ext.toUpperCase()}:`));
 
         for (const [key, fileGroup] of grouped) {
           if (!key.endsWith(`.${ext}`)) continue;
 
           if (fileGroup.normal) {
-            console.log(`   ${chalk.cyan(fileGroup.normal)}`);
+            console.error(`   ${chalk.cyan(fileGroup.normal)}`);
           }
           if (fileGroup.highlight) {
-            console.log(`   ${chalk.cyan(fileGroup.highlight)}`);
+            console.error(`   ${chalk.cyan(fileGroup.highlight)}`);
           }
         }
       }
     } else {
       // Simple list when no highlight
       for (const file of files) {
-        console.log(`   ${chalk.cyan(file)}`);
+        console.error(`   ${chalk.cyan(file)}`);
       }
     }
   }
@@ -585,20 +585,20 @@ export class CliService {
   private handleError(error: unknown): void {
     if (error instanceof PdfDependencyError) {
       this.log('PDF support is not currently installed.', 'error');
-      console.log(chalk.cyan('Install with: npm install puppeteer'));
-      console.log(
+      console.error(chalk.cyan('Install with: npm install puppeteer'));
+      console.error(
         chalk.cyan(
           'Or install Chrome/Chromium/Edge/Brave/Arc and use --pdf-connector=system-chrome'
         )
       );
-      console.log(chalk.cyan('Or install WeasyPrint and use --pdf-connector=weasyprint'));
+      console.error(chalk.cyan('Or install WeasyPrint and use --pdf-connector=weasyprint'));
       return;
     }
 
     if (error instanceof LegalMarkdownError) {
       this.log(`${error.name}: ${error.message}`, 'error');
       if (error.context && this.options.verbose) {
-        console.log('Context:', error.context);
+        console.error('Context:', error.context);
       }
     } else if (error instanceof Error) {
       this.log(`Error: ${error.message}`, 'error');

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -236,7 +236,7 @@ export class CliService {
           const resolvedOutputPath = this.resolveOutputPath(outputPath);
           writeFileSync(resolvedOutputPath, result.content);
           this.log(`Output written to: ${resolvedOutputPath}`, 'success');
-          console.log('Successfully processed');
+          console.error('Successfully processed');
         } else {
           console.log(result.content);
         }
@@ -247,7 +247,7 @@ export class CliService {
 
         if (result.metadata && this.options.verbose) {
           this.log('Metadata:', 'info');
-          console.log(JSON.stringify(result.metadata, null, 2));
+          console.error(JSON.stringify(result.metadata, null, 2));
         }
 
         // Archive source file if requested
@@ -329,13 +329,13 @@ export class CliService {
     };
 
     const prefix = {
-      info: '📝',
-      success: '✅',
-      warn: '⚠️',
-      error: '❌',
+      info: '[info]',
+      success: '[ok]',
+      warn: '[warn]',
+      error: '[error]',
     };
 
-    console.log(`${prefix[level]} ${colors[level](message)}`);
+    console.error(`${prefix[level]} ${colors[level](message)}`);
   }
 
   /**

--- a/src/core/exporters/metadata-exporter.ts
+++ b/src/core/exporters/metadata-exporter.ts
@@ -35,6 +35,7 @@
  */
 
 import * as fs from 'fs';
+import { logger } from '../../utils/logger';
 import * as path from 'path';
 import * as yaml from 'js-yaml';
 import type { YamlValue } from '../../types';
@@ -131,9 +132,12 @@ export function exportMetadata(
       const yamlContent = yaml.dump(exportedMetadata);
       fs.writeFileSync(yamlPath, yamlContent, 'utf8');
       exportedFiles.push(yamlPath);
-      console.log(`Exported YAML metadata to: ${yamlPath}`);
+      logger.debug(`Exported YAML metadata to: ${yamlPath}`);
     } catch (error) {
-      console.error('Error exporting YAML metadata:', error);
+      logger.error(
+        'Error exporting YAML metadata:',
+        error instanceof Error ? error.message : String(error)
+      );
     }
   }
 
@@ -153,9 +157,12 @@ export function exportMetadata(
       const jsonContent = JSON.stringify(exportedMetadata, null, 2);
       fs.writeFileSync(jsonPath, jsonContent, 'utf8');
       exportedFiles.push(jsonPath);
-      console.log(`Exported JSON metadata to: ${jsonPath}`);
+      logger.debug(`Exported JSON metadata to: ${jsonPath}`);
     } catch (error) {
-      console.error('Error exporting JSON metadata:', error);
+      logger.error(
+        'Error exporting JSON metadata:',
+        error instanceof Error ? error.message : String(error)
+      );
     }
   }
 

--- a/src/core/parsers/yaml-parser.ts
+++ b/src/core/parsers/yaml-parser.ts
@@ -40,6 +40,7 @@ import * as yaml from 'js-yaml';
 import { YamlParsingResult } from '../../types';
 import type { YamlValue } from '../../types';
 import { YamlParsingError } from '../../errors';
+import { logger } from '../../utils/logger';
 
 // ============================================================================
 // CUSTOM YAML SCHEMA FOR ISO DATE PARSING
@@ -292,7 +293,10 @@ export function serializeToYaml(metadata: Record<string, YamlValue>): string {
   try {
     return yaml.dump(metadata);
   } catch (error) {
-    console.error('Error serializing metadata to YAML:', error);
+    logger.error(
+      'Error serializing metadata to YAML:',
+      error instanceof Error ? error.message : String(error)
+    );
     return '';
   }
 }
@@ -390,7 +394,10 @@ function processDateReferencesInYaml(yamlContent: string): string {
       // Quote the date string to ensure it's valid YAML
       return `"${formattedDate}"`;
     } catch (error) {
-      console.warn(`Error processing YAML date reference ${match}:`, error);
+      logger.warn(
+        `Error processing YAML date reference ${match}:`,
+        error instanceof Error ? error.message : String(error)
+      );
       return `"${match}"`; // Return quoted original on error for valid YAML
     }
   });

--- a/src/core/pipeline/pipeline-builder.ts
+++ b/src/core/pipeline/pipeline-builder.ts
@@ -16,6 +16,7 @@ import type {
 import { PluginOrderValidator } from '../../plugins/remark/plugin-order-validator';
 import { PipelineError } from '../../errors';
 import { getRuntimeConfig } from '../../config/runtime';
+import { logger } from '../../utils/logger';
 
 /**
  * Ordered pipeline result from builder
@@ -200,7 +201,7 @@ export function validateCapabilities(
       for (const cap of metadata.capabilities) {
         providedCapabilities.add(cap);
         if (debug) {
-          console.log(`[PipelineBuilder] Plugin "${pluginName}" provides capability: ${cap}`);
+          logger.debug(`Plugin "${pluginName}" provides capability: ${cap}`);
         }
       }
     }
@@ -254,18 +255,18 @@ export function buildRemarkPipeline(
   const validationMode = config.validationMode || detectValidationMode();
 
   if (config.debug) {
-    console.log('[PipelineBuilder] Building pipeline with mode:', validationMode);
-    console.log('[PipelineBuilder] Requested plugins:', config.enabledPlugins);
+    logger.debug('Building pipeline with mode', validationMode);
+    logger.debug('Requested plugins', config.enabledPlugins);
   }
 
   // Step 2: Group plugins by phase
   const byPhase = groupPluginsByPhase(config.enabledPlugins, registry);
 
   if (config.debug) {
-    console.log('[PipelineBuilder] Plugins by phase:');
+    logger.debug('Plugins by phase:');
     for (const [phase, plugins] of byPhase.entries()) {
       if (plugins.length > 0) {
-        console.log(`  Phase ${phase}: ${plugins.join(', ')}`);
+        logger.debug(`  Phase ${phase}: ${plugins.join(', ')}`);
       }
     }
   }
@@ -277,7 +278,7 @@ export function buildRemarkPipeline(
     if (phasePlugins.length === 0) continue;
 
     if (config.debug) {
-      console.log(`[PipelineBuilder] Sorting phase ${phase} plugins:`, phasePlugins);
+      logger.debug(`Sorting phase ${phase} plugins`, phasePlugins);
     }
 
     const sorted = validator.topologicalSort(phasePlugins);
@@ -287,7 +288,7 @@ export function buildRemarkPipeline(
     byPhase.set(phase, sorted);
 
     if (config.debug) {
-      console.log(`[PipelineBuilder] Phase ${phase} sorted order:`, sorted);
+      logger.debug(`Phase ${phase} sorted order`, sorted);
     }
   }
 
@@ -303,14 +304,14 @@ export function buildRemarkPipeline(
 
   if (config.debug) {
     if (validation.valid) {
-      console.log('[PipelineBuilder] ✓ Validation passed');
+      logger.debug('Validation passed');
     } else {
-      console.log('[PipelineBuilder] ✗ Validation failed');
+      logger.debug('Validation failed');
       if (validation.errors.length > 0) {
-        console.log('[PipelineBuilder] Errors:', validation.errors);
+        logger.debug('Errors', validation.errors);
       }
       if (validation.warnings.length > 0) {
-        console.log('[PipelineBuilder] Warnings:', validation.warnings);
+        logger.debug('Warnings', validation.warnings);
       }
     }
   }
@@ -328,8 +329,8 @@ export function buildRemarkPipeline(
   validateCapabilities(orderedNames, registry, config.debug);
 
   if (config.debug) {
-    console.log('[PipelineBuilder] Final order:', orderedNames.join(' → '));
-    console.log('[PipelineBuilder] Capabilities provided:', Array.from(capabilities));
+    logger.debug('Final order', orderedNames.join(' → '));
+    logger.debug('Capabilities provided', Array.from(capabilities));
   }
 
   return {

--- a/src/core/pipeline/string-transformations.ts
+++ b/src/core/pipeline/string-transformations.ts
@@ -137,8 +137,8 @@ export async function applyStringTransformations(
   const metadata = { ...options.metadata };
 
   if (options.debug) {
-    console.log('[String Transformations] Starting Phase 2 transformations');
-    console.log('[String Transformations] Content length:', content.length);
+    logger.debug('Starting Phase 2 transformations');
+    logger.debug('Content length', content.length);
   }
 
   // ──────────────────────────────────────────────────────────────────────────
@@ -176,7 +176,7 @@ export async function applyStringTransformations(
   metadata['_field_mappings'] = mappings as unknown as YamlValue;
 
   if (options.debug && mappings.size > 0) {
-    console.log(`[String Transformations] Normalized ${mappings.size} custom field patterns`);
+    logger.debug(`Normalized ${mappings.size} custom field patterns`);
   }
 
   // ──────────────────────────────────────────────────────────────────────────
@@ -186,7 +186,7 @@ export async function applyStringTransformations(
   // This allows multi-line content with markdown formatting inside clauses
   if (!options.noClauses) {
     if (options.debug) {
-      console.log('[String Transformations] Processing optional clauses');
+      logger.debug('Processing optional clauses');
     }
 
     processedContent = preprocessOptionalClauses(
@@ -196,7 +196,7 @@ export async function applyStringTransformations(
     );
 
     if (options.debug) {
-      console.log('[String Transformations] Optional clauses processed');
+      logger.debug('Optional clauses processed');
     }
   }
 
@@ -206,7 +206,7 @@ export async function applyStringTransformations(
   // Handle Handlebars {{#each}}, {{#if}}, etc.
   // This must run AFTER field normalization so all fields use {{}} syntax
   if (options.debug) {
-    console.log('[String Transformations] Processing template loops (Handlebars)');
+    logger.debug('Processing template loops (Handlebars)');
   }
 
   const astFieldTracking = options.astFieldTracking ?? false;
@@ -222,8 +222,8 @@ export async function applyStringTransformations(
   );
 
   if (options.debug) {
-    console.log('[String Transformations] Template loops processed');
-    console.log('[String Transformations] Final content length:', processedContent.length);
+    logger.debug('Template loops processed');
+    logger.debug('Final content length', processedContent.length);
   }
 
   return {
@@ -285,10 +285,7 @@ function normalizeFieldPatterns(
   }
 
   if (debug && fieldMappings.size > 0) {
-    console.log(
-      '[normalizeFieldPatterns] Normalized patterns:',
-      Array.from(fieldMappings.entries())
-    );
+    logger.debug('Normalized patterns', Array.from(fieldMappings.entries()));
   }
 
   return {
@@ -376,7 +373,7 @@ function preprocessOptionalClauses(
   }
 
   if (debug && matches.length > 0) {
-    console.log(`[preprocessOptionalClauses] Found ${matches.length} optional clauses`);
+    logger.debug(`Found ${matches.length} optional clauses`);
   }
 
   // Process matches in reverse order to maintain correct positions
@@ -388,9 +385,7 @@ function preprocessOptionalClauses(
     const shouldInclude = Boolean(conditionValue);
 
     if (debug) {
-      console.log(
-        `[preprocessOptionalClauses] Condition "${condition}" = ${conditionValue} (include: ${shouldInclude})`
-      );
+      logger.debug(`Condition "${condition}" = ${conditionValue} (include: ${shouldInclude})`);
     }
 
     // Replace the clause with its content if true, or remove it if false

--- a/src/core/processors/date-processor.ts
+++ b/src/core/processors/date-processor.ts
@@ -44,6 +44,7 @@
  */
 
 import { ParseError } from '../../errors';
+import { logger } from '../../utils/logger';
 
 /**
  * Date format options that can be specified in YAML front matter
@@ -96,8 +97,8 @@ export interface DateFormatOptions {
 export function processDateReferences(content: string, metadata: Record<string, unknown>): string {
   // DEPRECATION WARNING
   if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'test') {
-    console.warn(
-      '[DEPRECATION] processDateReferences() is deprecated and will be removed in v4.0.0. ' +
+    logger.warn(
+      'processDateReferences() is deprecated and will be removed in v4.0.0. ' +
         'Use processLegalMarkdownWithRemark() with remarkDates plugin instead. ' +
         'See: https://github.com/yourrepo/legal-markdown-js/blob/main/docs/migration-guide.md'
     );

--- a/src/core/processors/import-processor.ts
+++ b/src/core/processors/import-processor.ts
@@ -44,6 +44,7 @@ import { ImportProcessingResult, LegalMarkdownOptions, YamlValue } from '../../t
 import { parseYamlFrontMatter } from '../parsers/yaml-parser';
 import { mergeSequentially, MergeOptions } from '../utils/frontmatter-merger';
 import { ImportError } from '../../errors';
+import { logger } from '../../utils/logger';
 
 /**
  * Processes partial imports in a LegalMarkdown document
@@ -104,8 +105,8 @@ export function processPartialImports(
 ): ImportProcessingResult {
   // DEPRECATION WARNING
   if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'test') {
-    console.warn(
-      '[DEPRECATION] processPartialImports() is deprecated and will be removed in v4.0.0. ' +
+    logger.warn(
+      'processPartialImports() is deprecated and will be removed in v4.0.0. ' +
         'Use processLegalMarkdownWithRemark() with remarkImports plugin instead. ' +
         'See: https://github.com/yourrepo/legal-markdown-js/blob/main/docs/migration-guide.md'
     );
@@ -166,7 +167,7 @@ export function processPartialImports(
 
           if (options?.logImportOperations) {
             const fieldCount = Object.keys(importedMetadata).length;
-            console.log(`Extracted ${fieldCount} metadata fields from ${cleanFilename}`);
+            logger.debug(`Extracted ${fieldCount} metadata fields from ${cleanFilename}`);
           }
         }
       }
@@ -210,7 +211,7 @@ export function processPartialImports(
 
     if (options?.logImportOperations) {
       const currentFieldCount = Object.keys(initialMetadata).length;
-      console.log(
+      logger.debug(
         `Merging metadata from ${importedMetadataList.length} imports with ${currentFieldCount} current fields`
       );
     }
@@ -231,15 +232,15 @@ export function processPartialImports(
     mergedMetadata = mergeResult.metadata;
 
     if (options?.logImportOperations && mergeResult.stats) {
-      console.log('Frontmatter merge completed:');
-      console.log(`  - Properties added: ${mergeResult.stats.propertiesAdded}`);
-      console.log(`  - Conflicts resolved: ${mergeResult.stats.conflictsResolved}`);
-      console.log(`  - Reserved fields filtered: ${mergeResult.stats.reservedFieldsFiltered}`);
+      logger.debug('Frontmatter merge completed:');
+      logger.debug(`  - Properties added: ${mergeResult.stats.propertiesAdded}`);
+      logger.debug(`  - Conflicts resolved: ${mergeResult.stats.conflictsResolved}`);
+      logger.debug(`  - Reserved fields filtered: ${mergeResult.stats.reservedFieldsFiltered}`);
       if (mergeResult.stats.addedFields.length > 0) {
-        console.log(`  - Added fields: ${mergeResult.stats.addedFields.join(', ')}`);
+        logger.debug(`  - Added fields: ${mergeResult.stats.addedFields.join(', ')}`);
       }
       if (mergeResult.stats.conflictedFields.length > 0) {
-        console.log(
+        logger.debug(
           `  - Conflicted fields (source wins): ${mergeResult.stats.conflictedFields.join(', ')}`
         );
       }
@@ -332,8 +333,8 @@ function resolveImportPath(importPath: string, basePath?: string): string {
 export function validateImports(content: string, basePath?: string): string[] {
   // DEPRECATION WARNING
   if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'test') {
-    console.warn(
-      '[DEPRECATION] validateImports() is deprecated and will be removed in v4.0.0. ' +
+    logger.warn(
+      'validateImports() is deprecated and will be removed in v4.0.0. ' +
         'Use processLegalMarkdownWithRemark() with remarkImports plugin instead. ' +
         'See: https://github.com/yourrepo/legal-markdown-js/blob/main/docs/migration-guide.md'
     );

--- a/src/core/utils/frontmatter-merger.ts
+++ b/src/core/utils/frontmatter-merger.ts
@@ -44,6 +44,7 @@ import {
   isBigIntTypedArray,
 } from './object-flattener';
 import { ProcessingError } from '../../errors';
+import { logger } from '../../utils/logger';
 import { filterReservedFields } from './reserved-fields-filter';
 import type { YamlValue } from '../../types';
 
@@ -224,7 +225,7 @@ export function mergeFlattened(
   stats.importedProperties = Object.keys(importedFlat).length;
 
   if (logOperations) {
-    console.log(
+    logger.debug(
       `Merging frontmatter: ${stats.currentProperties} current + ${stats.importedProperties} imported properties`
     );
   }
@@ -250,7 +251,7 @@ export function mergeFlattened(
           validateMergeCompatibility(currentValue, importedValue, key);
         } catch (error) {
           if (logOperations) {
-            console.warn(
+            logger.warn(
               `Type conflict for '${key}': ${error instanceof Error ? error.message : String(error)}`
             );
           }
@@ -265,7 +266,7 @@ export function mergeFlattened(
       stats.conflictedFields.push(key);
 
       if (logOperations) {
-        console.log(`Conflict for '${key}': current value kept`);
+        logger.debug(`Conflict for '${key}': current value kept`);
       }
     } else {
       // Check for nested conflicts in both directions
@@ -285,7 +286,7 @@ export function mergeFlattened(
         stats.addedFields.push(key);
 
         if (logOperations) {
-          console.log(`Added '${key}' from import`);
+          logger.debug(`Added '${key}' from import`);
         }
       }
     }
@@ -517,7 +518,7 @@ export function mergeSequentially(
     }
 
     if (options.logOperations) {
-      console.log(
+      logger.debug(
         `Merged import ${i + 1}/${imports.length}: +${result.stats?.propertiesAdded} properties`
       );
     }
@@ -555,7 +556,7 @@ function checkNestedConflicts(
         validateMergeCompatibility({}, importedValue, key);
       } catch (error) {
         if (logOperations) {
-          console.warn(
+          logger.warn(
             `Type conflict for '${key}': ${error instanceof Error ? error.message : String(error)}`
           );
         }
@@ -575,7 +576,7 @@ function checkNestedConflicts(
     } catch (error) {
       if (logOperations) {
         const message = error instanceof Error ? error.message : String(error);
-        console.warn(`Type conflict for '${baseKey}': ${message}`);
+        logger.warn(`Type conflict for '${baseKey}': ${message}`);
       }
       return { hasConflict: true, conflictedField: baseKey };
     }

--- a/src/core/utils/object-flattener.ts
+++ b/src/core/utils/object-flattener.ts
@@ -39,6 +39,7 @@
  */
 
 import { ProcessingError } from '../../errors';
+import { logger } from '../../utils/logger';
 
 /**
  * Numeric typed array constructors (Issue #141)
@@ -210,7 +211,7 @@ export function flattenObject(
 
   // Circular reference detection
   if (visited.has(objRecord)) {
-    console.warn(`Circular reference detected at path '${prefix}'. Replacing with placeholder.`);
+    logger.warn(`Circular reference detected at path '${prefix}'. Replacing with placeholder.`);
     if (prefix) {
       flattened[prefix] = '[Circular Reference]';
     }

--- a/src/core/utils/reserved-fields-filter.ts
+++ b/src/core/utils/reserved-fields-filter.ts
@@ -28,6 +28,8 @@
  * ```
  */
 
+import { logger } from '../../utils/logger';
+
 /**
  * Complete list of reserved field names that should not be imported
  *
@@ -141,7 +143,7 @@ export function filterReservedFields(
   for (const [key, value] of Object.entries(metadata)) {
     if (isReservedField(key, { additionalReserved, strictMode })) {
       if (logFiltered) {
-        console.warn(`Reserved field '${key}' ignored from import`);
+        logger.warn(`Reserved field '${key}' ignored from import`);
       }
     } else {
       filtered[key] = value;

--- a/src/extensions/ast-mixin-processor.ts
+++ b/src/extensions/ast-mixin-processor.ts
@@ -43,6 +43,7 @@
 
 import { LegalMarkdownOptions } from '../types';
 import type { YamlValue } from '../types';
+import { logger } from '../utils/logger';
 import { fieldTracker } from './tracking/field-tracker';
 import { extensionHelpers as helpers } from './helpers/index';
 
@@ -616,7 +617,10 @@ function resolveHelper(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic helper dispatch requires any to call unknown function signature
     return (helper as any)(...args) as YamlValue | undefined;
   } catch (error) {
-    console.warn(`Error evaluating helper expression: ${expression}`, error);
+    logger.warn('Error evaluating helper expression', {
+      expression,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return undefined;
   }
 }
@@ -650,7 +654,10 @@ function resolveConditional(
     // Parse the selected part as an argument (could be string, variable, etc.)
     return parseArgument(selectedPart, metadata);
   } catch (error) {
-    console.warn(`Error evaluating conditional expression: ${expression}`, error);
+    logger.warn('Error evaluating conditional expression', {
+      expression,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return undefined;
   }
 }
@@ -798,16 +805,15 @@ export function processMixins(
 
     // Log any parsing errors for debugging
     if (parseResult.hasErrors) {
-      console.warn('Mixin parsing errors detected:', parseResult.errors);
+      logger.warn('Mixin parsing errors detected', { errors: parseResult.errors });
     }
 
     // Process the AST and return resolved content
     return processMixinAST(parseResult.nodes, metadata, options);
   } catch (error) {
-    console.error(
-      'Critical error in AST mixin processing, falling back to original content:',
-      error
-    );
+    logger.error('Critical error in AST mixin processing, falling back to original content', {
+      error: error instanceof Error ? error.message : String(error),
+    });
 
     // Fallback: return original content if AST processing fails completely
     return content;

--- a/src/extensions/remark/legal-markdown-processor.ts
+++ b/src/extensions/remark/legal-markdown-processor.ts
@@ -768,7 +768,7 @@ export async function processLegalMarkdown(
     if (updatedOptions.debug) {
       logger.debug('Phase 2 complete. Content length', preprocessedContent.length);
       if (preprocessedContent.includes('{{#')) {
-        logger.debug('WARNING: Content still has {{# patterns!');
+        logger.warn('Content still has {{# patterns after Phase 2');
       }
     }
 

--- a/src/extensions/remark/legal-markdown-processor.ts
+++ b/src/extensions/remark/legal-markdown-processor.ts
@@ -67,6 +67,7 @@ import type { YamlValue } from '../../types';
 import { applyStringTransformations } from '../../core/pipeline/string-transformations';
 import { detectSyntaxType } from '../template-loops';
 import { parseForceCommands, applyForceCommands } from '../../core/parsers/force-commands-parser';
+import { logger } from '../../utils/logger';
 
 /**
  * Unsafe patterns for markdown serialization, excluding underscore patterns.
@@ -574,18 +575,21 @@ function createLegalMarkdownProcessor(
       });
 
       if (!result.valid && options.debug) {
-        console.warn('[LegalMarkdownProcessor] Plugin order validation warnings detected');
+        logger.warn('Plugin order validation warnings detected');
         for (const error of result.errors) {
-          console.warn(`  - ${error.message}`);
+          logger.warn(`  - ${error.message}`);
         }
         if (result.suggestedOrder) {
-          console.warn('  Suggested order:', result.suggestedOrder.join(' → '));
+          logger.warn('Suggested order', result.suggestedOrder.join(' → '));
         }
       }
     } catch (error) {
       // If validation fails, just log a warning in debug mode
       if (options.debug) {
-        console.warn('[LegalMarkdownProcessor] Plugin order validation failed:', error);
+        logger.warn(
+          'Plugin order validation failed',
+          error instanceof Error ? error.message : String(error)
+        );
       }
     }
   }
@@ -634,16 +638,13 @@ export async function processLegalMarkdown(
     fieldTracker.clear();
 
     if (options.debug) {
-      console.log('🔄 Starting Legal Markdown processing with remark pipeline');
+      logger.debug('Starting Legal Markdown processing with remark pipeline');
     }
 
     // Parse YAML front matter first
     if (options.debug) {
-      console.log('[legal-markdown-processor] Raw content length:', content.length);
-      console.log(
-        '[legal-markdown-processor] Raw content first 500 chars:',
-        content.substring(0, 500)
-      );
+      logger.debug('Raw content length', content.length);
+      logger.debug('Raw content first 500 chars', content.substring(0, 500));
     }
 
     const { content: contentWithoutYaml, metadata: yamlMetadata } = parseYamlFrontMatter(
@@ -652,8 +653,8 @@ export async function processLegalMarkdown(
     );
 
     if (options.debug) {
-      console.log('[legal-markdown-processor] YAML parsed:', Object.keys(yamlMetadata));
-      console.log('[legal-markdown-processor] Sample metadata:', yamlMetadata);
+      logger.debug('YAML parsed', Object.keys(yamlMetadata));
+      logger.debug('Sample metadata', yamlMetadata);
     }
 
     // Pre-process: Escape underscores inside {{}} to prevent markdown italic parsing
@@ -661,7 +662,7 @@ export async function processLegalMarkdown(
     const contentWithEscapedTemplates = escapeTemplateUnderscores(contentWithoutYaml);
 
     if (options.debug && contentWithEscapedTemplates !== contentWithoutYaml) {
-      console.log('[legal-markdown-processor] Escaped template underscores');
+      logger.debug('Escaped template underscores');
     }
 
     // If key processing is disabled, return original content without remark processing
@@ -669,7 +670,7 @@ export async function processLegalMarkdown(
     const keyProcessingDisabled = options.noHeaders && options.noReferences && options.noMixins;
 
     if (options.debug) {
-      console.log('[legal-markdown-processor] Processing flags:', {
+      logger.debug('Processing flags', {
         noHeaders: options.noHeaders,
         noReferences: options.noReferences,
         noMixins: options.noMixins,
@@ -680,9 +681,7 @@ export async function processLegalMarkdown(
 
     if (keyProcessingDisabled && !options.enableFieldTracking) {
       if (options.debug) {
-        console.log(
-          '[legal-markdown-processor] Key processing disabled, returning original content'
-        );
+        logger.debug('Key processing disabled, returning original content');
       }
 
       return {
@@ -732,19 +731,10 @@ export async function processLegalMarkdown(
     }
 
     if (updatedOptions.debug) {
-      console.log(
-        '[legal-markdown-processor] Combined metadata keys:',
-        Object.keys(combinedMetadata)
-      );
-      console.log('[legal-markdown-processor] Combined metadata sample:', combinedMetadata);
-      console.log(
-        '[legal-markdown-processor] Services structure:',
-        JSON.stringify(combinedMetadata.services, null, 2)
-      );
-      console.log(
-        '[legal-markdown-processor] Milestones structure:',
-        JSON.stringify(combinedMetadata.milestones, null, 2)
-      );
+      logger.debug('Combined metadata keys', Object.keys(combinedMetadata));
+      logger.debug('Combined metadata sample', combinedMetadata);
+      logger.debug('Services structure', JSON.stringify(combinedMetadata.services, null, 2));
+      logger.debug('Milestones structure', JSON.stringify(combinedMetadata.milestones, null, 2));
     }
 
     const trackingOptions = resolveTrackingOptions(updatedOptions);
@@ -756,7 +746,7 @@ export async function processLegalMarkdown(
     // This includes: field normalization, optional clauses, template loops
     // See: docs/architecture/string-transformations.md
     if (updatedOptions.debug) {
-      console.log('[legal-markdown-processor] Starting Phase 2: String Transformations');
+      logger.debug('Starting Phase 2: String Transformations');
     }
 
     const stringTransformResult = await applyStringTransformations(contentWithEscapedTemplates, {
@@ -776,12 +766,9 @@ export async function processLegalMarkdown(
     Object.assign(combinedMetadata, stringTransformResult.metadata);
 
     if (updatedOptions.debug) {
-      console.log(
-        '[legal-markdown-processor] Phase 2 complete. Content length:',
-        preprocessedContent.length
-      );
+      logger.debug('Phase 2 complete. Content length', preprocessedContent.length);
       if (preprocessedContent.includes('{{#')) {
-        console.log('[legal-markdown-processor] WARNING: Content still has {{# patterns!');
+        logger.debug('WARNING: Content still has {{# patterns!');
       }
     }
 
@@ -807,7 +794,7 @@ export async function processLegalMarkdown(
     }
 
     if (updatedOptions.debug) {
-      console.log(`📋 Using plugins: ${pluginsUsed.join(', ')}`);
+      logger.debug(`Using plugins: ${pluginsUsed.join(', ')}`);
     }
 
     // Process the content (field highlighting is now done during AST processing)
@@ -839,8 +826,8 @@ export async function processLegalMarkdown(
     };
 
     if (updatedOptions.debug && Object.keys(importedMetadata).length > 0) {
-      console.log(
-        `📦 Merged ${Object.keys(importedMetadata).length} imported metadata fields:`,
+      logger.debug(
+        `Merged ${Object.keys(importedMetadata).length} imported metadata fields`,
         Object.keys(importedMetadata)
       );
     }
@@ -889,21 +876,24 @@ export async function processLegalMarkdown(
         exportedFiles = exportResult.exportedFiles;
 
         if (updatedOptions.debug) {
-          console.log(`📁 Exported metadata files: ${exportedFiles.join(', ')}`);
+          logger.debug(`Exported metadata files: ${exportedFiles.join(', ')}`);
         }
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         warnings.push(`Failed to export metadata: ${errorMessage}`);
         if (updatedOptions.debug) {
-          console.warn('⚠️ Metadata export failed:', error);
+          logger.warn(
+            'Metadata export failed',
+            error instanceof Error ? error.message : String(error)
+          );
         }
       }
     }
 
     if (updatedOptions.debug) {
-      console.log(`✅ Processing completed in ${Date.now() - startTime}ms`);
-      console.log(`📊 Cross-references found: ${crossReferencesFound}`);
-      console.log(`📋 Fields tracked: ${fieldsTracked}`);
+      logger.debug(`Processing completed in ${Date.now() - startTime}ms`);
+      logger.debug(`Cross-references found: ${crossReferencesFound}`);
+      logger.debug(`Fields tracked: ${fieldsTracked}`);
     }
 
     return {
@@ -922,7 +912,10 @@ export async function processLegalMarkdown(
     };
   } catch (error) {
     if (options.debug) {
-      console.error('❌ Legal Markdown processing failed:', error);
+      logger.error(
+        'Legal Markdown processing failed',
+        error instanceof Error ? error.message : String(error)
+      );
     }
 
     // Re-throw with additional context

--- a/src/plugins/remark/clauses.ts
+++ b/src/plugins/remark/clauses.ts
@@ -36,6 +36,7 @@ import { visit } from 'unist-util-visit';
 import { fieldTracker } from '../../extensions/tracking/field-tracker';
 import { fieldSpan } from '../../extensions/tracking/field-span';
 import type { YamlValue } from '../../types';
+import { logger } from '../../utils/logger';
 
 /**
  * Options for the remark clauses plugin
@@ -85,7 +86,7 @@ export const remarkClauses: Plugin<[RemarkClausesOptions], Root> = options => {
 
   return (tree: Root) => {
     if (debug) {
-      console.log('[remarkClauses] Processing clauses with metadata:', Object.keys(metadata));
+      logger.debug('Processing clauses with metadata:', Object.keys(metadata));
     }
 
     // Process all text nodes that might contain conditional blocks
@@ -115,8 +116,8 @@ function processTextNode(
   const conditionalBlocks = extractConditionalBlocks(originalText);
 
   if (debug && originalText.includes('{{#')) {
-    console.log(`[remarkClauses] DEBUG - Text node content: "${originalText}"`);
-    console.log(`[remarkClauses] DEBUG - Found ${conditionalBlocks.length} conditional blocks`);
+    logger.debug(`Text node content: "${originalText}"`);
+    logger.debug(`Found ${conditionalBlocks.length} conditional blocks`);
   }
 
   if (conditionalBlocks.length === 0) {
@@ -124,9 +125,7 @@ function processTextNode(
   }
 
   if (debug) {
-    console.log(
-      `[remarkClauses] Found ${conditionalBlocks.length} conditional blocks in text node`
-    );
+    logger.debug(`Found ${conditionalBlocks.length} conditional blocks in text node`);
   }
 
   // Process blocks in reverse order to maintain correct positions
@@ -166,9 +165,7 @@ function processHtmlNode(
   }
 
   if (debug) {
-    console.log(
-      `[remarkClauses] Found ${conditionalBlocks.length} conditional blocks in HTML node`
-    );
+    logger.debug(`Found ${conditionalBlocks.length} conditional blocks in HTML node`);
   }
 
   // Process blocks in reverse order to maintain correct positions
@@ -302,7 +299,7 @@ function evaluateConditionalBlock(
       const result = evaluateCondition(actualCondition, metadata);
 
       if (debug) {
-        console.log(`[remarkClauses] Conditional "if ${actualCondition}" evaluated to:`, result);
+        logger.debug(`Conditional "if ${actualCondition}" evaluated to:`, result);
       }
 
       if (result) {
@@ -319,8 +316,8 @@ function evaluateConditionalBlock(
 
     if (Array.isArray(value)) {
       if (debug) {
-        console.log(
-          `[remarkClauses] Array condition "${condition}" with ${value.length} items - processing as loop`
+        logger.debug(
+          `Array condition "${condition}" with ${value.length} items - processing as loop`
         );
       }
       // Process as array loop
@@ -331,7 +328,7 @@ function evaluateConditionalBlock(
     const result = evaluateCondition(condition, metadata);
 
     if (debug) {
-      console.log(`[remarkClauses] Condition "${condition}" evaluated to:`, result);
+      logger.debug(`Condition "${condition}" evaluated to:`, result);
     }
 
     if (result) {
@@ -343,7 +340,9 @@ function evaluateConditionalBlock(
     }
   } catch (error) {
     if (debug) {
-      console.warn(`[remarkClauses] Error evaluating condition "${condition}":`, error);
+      logger.warn(
+        `Error evaluating condition "${condition}": ${error instanceof Error ? error.message : String(error)}`
+      );
     }
     // On error, include the content by default (safe behavior)
     return content;
@@ -376,7 +375,7 @@ function evaluateCondition(condition: string, metadata: Record<string, YamlValue
 function sanitizeCondition(condition: string): string | null {
   // Check for HTML tags (dangerous)
   if (/<[^>]*>/.test(condition)) {
-    console.warn('[remarkClauses] Unsafe condition detected, skipping:', condition);
+    logger.warn(`Unsafe condition detected, skipping: ${condition}`);
     return null;
   }
 
@@ -385,7 +384,7 @@ function sanitizeCondition(condition: string): string | null {
   const lowerCondition = condition.toLowerCase();
   for (const keyword of dangerousKeywords) {
     if (lowerCondition.includes(keyword)) {
-      console.warn('[remarkClauses] Unsafe condition detected, skipping:', condition);
+      logger.warn(`Unsafe condition detected, skipping: ${condition}`);
       return null;
     }
   }
@@ -394,7 +393,7 @@ function sanitizeCondition(condition: string): string | null {
   const safePattern = /^[a-zA-Z0-9_.\s==!=<>!&|()'"@]+$/;
 
   if (!safePattern.test(condition)) {
-    console.warn('[remarkClauses] Unsafe condition detected, skipping:', condition);
+    logger.warn(`Unsafe condition detected, skipping: ${condition}`);
     return null;
   }
 
@@ -669,7 +668,7 @@ function processArrayLoop(
       const value = getNestedValue(enhancedMetadata, trimmedField);
 
       if (debug) {
-        console.log(`[remarkClauses] Loop field "${trimmedField}" resolved to:`, value);
+        logger.debug(`Loop field "${trimmedField}" resolved to:`, value);
       }
 
       // Apply field tracking if enabled

--- a/src/plugins/remark/cross-references-ast.ts
+++ b/src/plugins/remark/cross-references-ast.ts
@@ -37,6 +37,7 @@ import { fieldTracker } from '../../extensions/tracking/field-tracker';
 import { fieldSpan } from '../../extensions/tracking/field-span';
 import { DEFAULT_HEADER_PATTERNS } from '../../constants/headers';
 import type { YamlValue } from '../../types';
+import { logger } from '../../utils/logger';
 
 /**
  * Custom AST node type for cross-references
@@ -260,7 +261,7 @@ function extractDefinitionsFromAST(
       });
 
       if (debug) {
-        console.log(`[CrossRefAST] Found definition: ${definitionKey} -> ${sectionNumber}`);
+        logger.debug(`Found definition: ${definitionKey} -> ${sectionNumber}`);
       }
     }
   });
@@ -455,7 +456,7 @@ function resolveReferences(
     });
 
     if (debug) {
-      console.log(`[CrossRefAST] Resolving ${key} -> ${resolvedValue || 'UNRESOLVED'}`);
+      logger.debug(`Resolving ${key} -> ${resolvedValue || 'UNRESOLVED'}`);
     }
 
     // Create replacement node
@@ -562,7 +563,7 @@ export const remarkCrossReferencesAST: Plugin<[CrossReferenceASTOptions], Root> 
 
   return (tree: Root) => {
     if (debug) {
-      console.log('🔗 [CrossRefAST] Starting enhanced cross-reference processing');
+      logger.debug('Starting enhanced cross-reference processing');
     }
 
     // Phase 1: Parse |key| patterns into custom reference nodes
@@ -572,8 +573,8 @@ export const remarkCrossReferencesAST: Plugin<[CrossReferenceASTOptions], Root> 
     const crossReferences = extractDefinitionsFromAST(tree, metadata, debug);
 
     if (debug) {
-      console.log(
-        `[CrossRefAST] Found ${crossReferences.length} definitions:`,
+      logger.debug(
+        `Found ${crossReferences.length} definitions:`,
         crossReferences.map(ref => `${ref.key} -> ${ref.sectionNumber}`)
       );
     }
@@ -592,7 +593,7 @@ export const remarkCrossReferencesAST: Plugin<[CrossReferenceASTOptions], Root> 
     cleanupDefinitions(tree);
 
     if (debug) {
-      console.log('✅ [CrossRefAST] Enhanced cross-reference processing completed');
+      logger.debug('Enhanced cross-reference processing completed');
     }
   };
 };

--- a/src/plugins/remark/cross-references.ts
+++ b/src/plugins/remark/cross-references.ts
@@ -338,10 +338,10 @@ function extractCrossReferencesFromAST(
       const misplacedMatch = headingText.match(/^(?:l+\.\s+)?(.+?)\s+\|([^|]+)\|\s+\S/);
       if (misplacedMatch) {
         const key = misplacedMatch[2].trim();
-        logger.warn(
-          `[remarkCrossReferences] |${key}| found in heading but not at end - definition will not be extracted`,
-          { key, line: node.position?.start.line }
-        );
+        logger.warn(`|${key}| found in heading but not at end - definition will not be extracted`, {
+          key,
+          line: node.position?.start.line,
+        });
         appendMisplacedKeyBadge(node);
       }
     }
@@ -657,14 +657,14 @@ const remarkCrossReferences: Plugin<[CrossReferenceOptions], Root> = options => 
 
   return (tree: Root) => {
     if (debug) {
-      console.log('🔗 Processing cross-references with remark plugin');
+      logger.debug('Processing cross-references with remark plugin');
     }
 
     // First pass: Extract cross-reference definitions from headers
     const crossReferences = extractCrossReferencesFromAST(tree, metadata, debug);
 
     if (debug) {
-      console.log(
+      logger.debug(
         `Found ${crossReferences.length} cross-reference definitions:`,
         crossReferences.map(ref => `${ref.key} -> ${ref.sectionNumber}`)
       );
@@ -687,12 +687,12 @@ const remarkCrossReferences: Plugin<[CrossReferenceOptions], Root> = options => 
 
     // Third pass: Replace cross-reference usage with section numbers
     if (debug) {
-      console.log('🔄 Starting cross-reference replacement in content...');
+      logger.debug('Starting cross-reference replacement in content...');
     }
     replaceCrossReferencesInAST(tree, crossReferences, metadata, enableFieldTracking);
 
     if (debug) {
-      console.log('✅ Cross-reference processing completed');
+      logger.debug('Cross-reference processing completed');
     }
   };
 };

--- a/src/plugins/remark/dates.ts
+++ b/src/plugins/remark/dates.ts
@@ -52,6 +52,7 @@ import { addDays, addMonths, addYears } from '../../extensions/helpers/advanced-
 import { fieldTracker } from '../../extensions/tracking/field-tracker';
 import { fieldSpan } from '../../extensions/tracking/field-span';
 import type { YamlValue } from '../../types';
+import { logger } from '../../utils/logger';
 
 /**
  * Plugin options for date processing
@@ -308,7 +309,7 @@ function processDateReferencesInAST(
         hasChanges = true;
         return formatDateValue(formattedDate, fullToken, enableFieldTracking, hasArithmetic);
       } catch (error) {
-        console.warn(`Error processing date reference ${match}:`, error);
+        logger.warn(`Error processing date reference ${match}:`, error);
         return match; // Return original on error
       }
     });
@@ -381,7 +382,7 @@ function processDateReferencesInAST(
             return formattedDate;
           }
         } catch (error) {
-          console.warn(`Error processing date reference ${match}:`, error);
+          logger.warn(`Error processing date reference ${match}:`, error);
           return match;
         }
       }
@@ -402,14 +403,14 @@ const remarkDates: Plugin<[DateProcessingOptions], Root> = options => {
 
   return (tree: Root) => {
     if (debug) {
-      console.log('📅 Processing date references with remark plugin');
+      logger.debug('Processing date references with remark plugin');
     }
 
     // Process date references in the AST
     processDateReferencesInAST(tree, metadata, enableFieldTracking);
 
     if (debug) {
-      console.log('✅ Date reference processing completed');
+      logger.debug('Date reference processing completed');
     }
   };
 };

--- a/src/plugins/remark/dates.ts
+++ b/src/plugins/remark/dates.ts
@@ -309,7 +309,10 @@ function processDateReferencesInAST(
         hasChanges = true;
         return formatDateValue(formattedDate, fullToken, enableFieldTracking, hasArithmetic);
       } catch (error) {
-        logger.warn(`Error processing date reference ${match}:`, error);
+        logger.warn(
+          `Error processing date reference ${match}:`,
+          error instanceof Error ? error.message : String(error)
+        );
         return match; // Return original on error
       }
     });
@@ -382,7 +385,10 @@ function processDateReferencesInAST(
             return formattedDate;
           }
         } catch (error) {
-          logger.warn(`Error processing date reference ${match}:`, error);
+          logger.warn(
+            `Error processing date reference ${match}:`,
+            error instanceof Error ? error.message : String(error)
+          );
           return match;
         }
       }

--- a/src/plugins/remark/debug-ast.ts
+++ b/src/plugins/remark/debug-ast.ts
@@ -9,7 +9,7 @@ import { visit } from 'unist-util-visit';
 
 export const remarkDebugAST: Plugin<[], Root> = () => {
   return (tree: Root) => {
-    console.log('\n=== AST DEBUG ===');
+    process.stderr.write('\n=== AST DEBUG ===\n');
 
     let nodeCount = 0;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- unist-util-visit generic node callback
@@ -17,16 +17,16 @@ export const remarkDebugAST: Plugin<[], Root> = () => {
       if (node.type === 'text' || node.type === 'html') {
         const value: string = node.value || '';
         if (value.includes('{{#') || value.includes('{{/')) {
-          console.log(`\nNode #${nodeCount} (${node.type}):`);
-          console.log('Value:', JSON.stringify(value));
-          console.log('Parent type:', parent?.type);
-          console.log('Full value length:', value.length);
+          process.stderr.write(`\nNode #${nodeCount} (${node.type}):\n`);
+          process.stderr.write(`Value: ${JSON.stringify(value)}\n`);
+          process.stderr.write(`Parent type: ${JSON.stringify(parent?.type)}\n`);
+          process.stderr.write(`Full value length: ${JSON.stringify(value.length)}\n`);
         }
       }
       nodeCount++;
     });
 
-    console.log(`\nTotal nodes visited: ${nodeCount}`);
-    console.log('=== END AST DEBUG ===\n');
+    process.stderr.write(`\nTotal nodes visited: ${nodeCount}\n`);
+    process.stderr.write('=== END AST DEBUG ===\n\n');
   };
 };

--- a/src/plugins/remark/field-tracking.ts
+++ b/src/plugins/remark/field-tracking.ts
@@ -34,6 +34,7 @@ import type { Plugin } from 'unified';
 import type { Root, Text, Node } from 'mdast';
 import { fieldTracker } from '../../extensions/tracking/field-tracker';
 import type { YamlValue } from '../../types';
+import { logger } from '../../utils/logger';
 
 /**
  * Configuration options for the field tracking plugin
@@ -183,7 +184,7 @@ function trackFieldsInTextNode(
       results.push(result);
 
       if (debug) {
-        console.log(`📋 Tracked field: ${fieldName} = "${resolvedValue}" (${originalValue})`);
+        logger.debug(`Tracked field: ${fieldName} = "${resolvedValue}" (${originalValue})`);
       }
     }
   }
@@ -205,14 +206,14 @@ const remarkFieldTracking: Plugin<[FieldTrackingOptions?], Root> = (options = {}
   return (tree: Root) => {
     if (!trackingEnabled) {
       if (debug) {
-        console.log('📋 Field tracking is disabled');
+        logger.debug('Field tracking is disabled');
       }
       return;
     }
 
     if (debug) {
-      console.log('📋 Processing field tracking with remark plugin');
-      console.log(`📋 Using patterns: ${patterns.join(', ')}`);
+      logger.debug('Processing field tracking with remark plugin');
+      logger.debug(`Using patterns: ${patterns.join(', ')}`);
     }
 
     let totalFieldsTracked = 0;
@@ -244,8 +245,8 @@ const remarkFieldTracking: Plugin<[FieldTrackingOptions?], Root> = (options = {}
     }
 
     if (debug) {
-      console.log(
-        `📋 Field tracking completed: ${totalFieldsTracked} fields tracked (${trackedFields.size} unique)`
+      logger.debug(
+        `Field tracking completed: ${totalFieldsTracked} fields tracked (${trackedFields.size} unique)`
       );
     }
   };

--- a/src/plugins/remark/headers.ts
+++ b/src/plugins/remark/headers.ts
@@ -37,6 +37,7 @@ import { Root, Heading } from 'mdast';
 import { visit } from 'unist-util-visit';
 import { DEFAULT_HEADER_PATTERNS } from '../../constants/headers';
 import type { YamlValue } from '../../types';
+import { logger } from '../../utils/logger';
 
 /** Extended heading node with remark-specific data properties */
 interface LegalHeading extends Heading {
@@ -117,8 +118,8 @@ export const remarkHeaders: Plugin<[RemarkHeadersOptions], Root> = options => {
 
   return (tree: Root) => {
     if (debug) {
-      console.log('[remarkHeaders] Processing headers with options:', options);
-      console.log('[remarkHeaders] Metadata:', metadata);
+      logger.debug('Processing headers with options:', options);
+      logger.debug('Metadata:', metadata);
     }
 
     // Initialize header configuration from metadata
@@ -134,15 +135,15 @@ export const remarkHeaders: Plugin<[RemarkHeadersOptions], Root> = options => {
     });
 
     if (debug) {
-      console.log(`[remarkHeaders] Found ${headingCount} legal headings in document`);
+      logger.debug(`Found ${headingCount} legal headings in document`);
     }
 
     // Process only headings that come from legal header syntax
     visit(tree, 'heading', (node: Heading, _index, _parent) => {
       if ((node as LegalHeading).data?.isLegalHeader) {
         if (debug) {
-          console.log(
-            `[remarkHeaders] Processing legal heading at depth ${node.depth}:`,
+          logger.debug(
+            `Processing legal heading at depth ${node.depth}:`,
             extractTextContent(node)
           );
         }
@@ -154,7 +155,7 @@ export const remarkHeaders: Plugin<[RemarkHeadersOptions], Root> = options => {
     visit(tree, 'heading', (node: Heading, index, parent) => {
       if ((node as LegalHeading).__needsHtmlReplacement && parent && typeof index === 'number') {
         if (debug) {
-          console.log('[remarkHeaders] Replacing heading with HTML node to preserve indentation');
+          logger.debug('Replacing heading with HTML node to preserve indentation');
         }
 
         // Replace the heading node with an HTML node
@@ -168,7 +169,7 @@ export const remarkHeaders: Plugin<[RemarkHeadersOptions], Root> = options => {
     });
 
     if (debug) {
-      console.log('[remarkHeaders] Final header state:', state);
+      logger.debug('Final header state:', state);
     }
   };
 };
@@ -312,8 +313,8 @@ function processHeader(
   }
 
   if (debug) {
-    console.log(`[remarkHeaders] Processed level ${level} header:`, headerText);
-    console.log(`[remarkHeaders] Added CSS class:`, cssClass);
+    logger.debug(`Processed level ${level} header:`, headerText);
+    logger.debug('Added CSS class:', cssClass);
   }
 }
 
@@ -504,7 +505,7 @@ function formatHeaderText(
 
   if (!currentText) {
     if (debug) {
-      console.log('[remarkHeaders] No text content found in header');
+      logger.debug('No text content found in header');
     }
     return null;
   }
@@ -512,7 +513,7 @@ function formatHeaderText(
   // Check if header already has numbering
   if (hasExistingNumbering(currentText, format)) {
     if (debug) {
-      console.log('[remarkHeaders] Header already has numbering, skipping');
+      logger.debug('Header already has numbering, skipping');
     }
     return null;
   }

--- a/src/plugins/remark/imports.ts
+++ b/src/plugins/remark/imports.ts
@@ -44,6 +44,7 @@ import { parseYamlFrontMatter } from '../../core/parsers/yaml-parser';
 import { mergeSequentially, MergeOptions, MergeResult } from '../../core/utils/frontmatter-merger';
 import type { PluginMetadata } from './types';
 import { ProcessingPhase } from './types';
+import { logger } from '../../utils/logger';
 
 /**
  * Options for the remark imports plugin
@@ -211,7 +212,7 @@ export const remarkImports: Plugin<[RemarkImportsOptions], Root> = options => {
     const startTime = Date.now();
 
     if (debug) {
-      console.log('[remarkImports] Processing imports with options:', {
+      logger.debug('Processing imports with options:', {
         basePath,
         mergeMetadata,
         maxDepth,
@@ -327,7 +328,7 @@ async function processParagraphWithImports(
     }
 
     if (context.debug) {
-      console.log(`[remarkImports] Found ${directives.length} import directives`);
+      logger.debug(`Found ${directives.length} import directives`);
     }
 
     // Process each import directive and build AST nodes
@@ -433,8 +434,8 @@ async function processImportDirectiveToAST(
   context: ImportContext
 ): Promise<Content[]> {
   if (context.depth >= context.maxDepth) {
-    console.warn(
-      `[remarkImports] Maximum import depth (${context.maxDepth}) reached for file "${directive.filePath}"`
+    logger.warn(
+      `Maximum import depth (${context.maxDepth}) reached for file "${directive.filePath}"`
     );
     // Return the original directive as text
     return [{ type: 'text', value: directive.fullMatch }];
@@ -447,21 +448,19 @@ async function processImportDirectiveToAST(
 
   // Check for circular imports
   if (context.importStack.includes(canonicalPath)) {
-    console.warn(`[remarkImports] Circular import detected: ${canonicalPath}`);
+    logger.warn(`Circular import detected: ${canonicalPath}`);
     return [{ type: 'text', value: directive.fullMatch }];
   }
 
   if (context.debug) {
-    console.log(
-      `[remarkImports] Processing import "${directive.filePath}" (resolved: ${normalizedPath})`
-    );
+    logger.debug(`Processing import "${directive.filePath}" (resolved: ${normalizedPath})`);
   }
 
   // Load file content
   const fileContent = loadFileContent(canonicalPath, context);
 
   if (!fileContent) {
-    console.warn(`[remarkImports] Import file not found: ${directive.filePath}`);
+    logger.warn(`Import file not found: ${directive.filePath}`);
     return [{ type: 'text', value: directive.fullMatch }];
   }
 
@@ -491,10 +490,7 @@ async function processImportDirectiveToAST(
       }
 
       if (context.debug) {
-        console.log(
-          `[remarkImports] Collected metadata from ${directive.filePath}:`,
-          Object.keys(metadata)
-        );
+        logger.debug(`Collected metadata from ${directive.filePath}:`, Object.keys(metadata));
       }
     }
   }
@@ -571,9 +567,7 @@ function performSequentialMerge(context: ImportContext): MergeResult {
   const metadataList = context.importedMetadataList.map(item => item.metadata);
 
   if (context.debug) {
-    console.log(
-      `[remarkImports] Performing sequential merge of ${metadataList.length} metadata objects`
-    );
+    logger.debug(`Performing sequential merge of ${metadataList.length} metadata objects`);
   }
 
   try {
@@ -588,7 +582,9 @@ function performSequentialMerge(context: ImportContext): MergeResult {
     return result;
   } catch (error) {
     if (context.debug) {
-      console.warn('[remarkImports] Sequential merge failed:', error);
+      logger.warn(
+        `Sequential merge failed: ${error instanceof Error ? error.message : String(error)}`
+      );
     }
     throw error;
   }
@@ -611,7 +607,9 @@ function loadFileContent(filePath: string, context: ImportContext): string | nul
     }
   } catch (error) {
     if (context.debug) {
-      console.warn(`[remarkImports] Failed to load import file "${filePath}":`, error);
+      logger.warn(
+        `Failed to load import file "${filePath}": ${error instanceof Error ? error.message : String(error)}`
+      );
     }
   }
 
@@ -656,7 +654,7 @@ function extractSection(content: string, sectionName: string, debug: boolean): s
         sectionStart = i + 1; // Start after the header
         sectionLevel = level;
         if (debug) {
-          console.log(`[remarkImports] Found section '${sectionName}' at line ${i}`);
+          logger.debug(`Found section '${sectionName}' at line ${i}`);
         }
         break;
       }
@@ -665,7 +663,7 @@ function extractSection(content: string, sectionName: string, debug: boolean): s
 
   if (sectionStart === -1) {
     if (debug) {
-      console.warn(`[remarkImports] Section '${sectionName}' not found`);
+      logger.debug(`Section '${sectionName}' not found`);
     }
     return content; // Return full content if section not found
   }

--- a/src/plugins/remark/legal-headers-parser.ts
+++ b/src/plugins/remark/legal-headers-parser.ts
@@ -26,6 +26,7 @@
 import { Plugin } from 'unified';
 import { Root, Paragraph, Heading } from 'mdast';
 import { visit } from 'unist-util-visit';
+import { logger } from '../../utils/logger';
 
 interface LegalHeadersParserOptions {
   debug?: boolean;
@@ -146,7 +147,7 @@ const remarkLegalHeadersParser: Plugin<[LegalHeadersParserOptions?], Root> = (op
 
   return (tree: Root) => {
     if (debug) {
-      console.log('🔍 [remarkLegalHeadersParser] Parsing legal header syntax');
+      logger.debug('Parsing legal header syntax');
     }
 
     let convertedCount = 0;
@@ -196,8 +197,8 @@ const remarkLegalHeadersParser: Plugin<[LegalHeadersParserOptions?], Root> = (op
                   const level = getHeadingLevel(levelPattern);
 
                   if (debug) {
-                    console.log(
-                      `🔄 [remarkLegalHeadersParser] Converting HTML legal header (multiline) to level ${level} heading`
+                    logger.debug(
+                      `Converting HTML legal header (multiline) to level ${level} heading`
                     );
                   }
 
@@ -251,9 +252,7 @@ const remarkLegalHeadersParser: Plugin<[LegalHeadersParserOptions?], Root> = (op
               const level = getHeadingLevel(levelPattern);
 
               if (debug) {
-                console.log(
-                  `🔄 [remarkLegalHeadersParser] Converting HTML legal header to level ${level} heading`
-                );
+                logger.debug(`Converting HTML legal header to level ${level} heading`);
               }
 
               // Create a heading with the HTML content (minus the l. prefix)
@@ -314,8 +313,8 @@ const remarkLegalHeadersParser: Plugin<[LegalHeadersParserOptions?], Root> = (op
                 const level = getHeadingLevel(levelPattern);
 
                 if (debug) {
-                  console.log(
-                    `🔄 [remarkLegalHeadersParser] Converting "${line.substring(0, 50)}..." to level ${level} heading`
+                  logger.debug(
+                    `Converting "${line.substring(0, 50)}..." to level ${level} heading`
                   );
                 }
 
@@ -429,8 +428,8 @@ const remarkLegalHeadersParser: Plugin<[LegalHeadersParserOptions?], Root> = (op
                 const level = getHeadingLevel(levelPattern);
 
                 if (debug) {
-                  console.log(
-                    `🔄 [remarkLegalHeadersParser] Converting complex "${line.substring(0, 50)}..." to level ${level} heading`
+                  logger.debug(
+                    `Converting complex "${line.substring(0, 50)}..." to level ${level} heading`
                   );
                 }
 
@@ -478,15 +477,15 @@ const remarkLegalHeadersParser: Plugin<[LegalHeadersParserOptions?], Root> = (op
         if (debug) {
           const firstChildText =
             node.children[0]?.type === 'text' ? node.children[0].value : '<non-text>';
-          console.log(`🔍 [remarkLegalHeadersParser] Single-line paragraph: "${firstChildText}"`);
+          logger.debug(`Single-line paragraph: "${firstChildText}"`);
         }
         const headerInfo = isLegalHeader(node);
 
         if (headerInfo && parent && typeof index === 'number') {
           if (debug) {
             const firstChildText = node.children[0].type === 'text' ? node.children[0].value : '';
-            console.log(
-              `🔄 [remarkLegalHeadersParser] Converting "${firstChildText.substring(0, 50)}..." to level ${headerInfo.level} heading`
+            logger.debug(
+              `Converting "${firstChildText.substring(0, 50)}..." to level ${headerInfo.level} heading`
             );
           }
 
@@ -506,7 +505,7 @@ const remarkLegalHeadersParser: Plugin<[LegalHeadersParserOptions?], Root> = (op
     }
 
     if (debug) {
-      console.log(`✅ [remarkLegalHeadersParser] Converted ${convertedCount} legal headers`);
+      logger.debug(`Converted ${convertedCount} legal headers`);
     }
   };
 };

--- a/src/plugins/remark/mixins.ts
+++ b/src/plugins/remark/mixins.ts
@@ -38,6 +38,7 @@ import { visit } from 'unist-util-visit';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { YamlValue } from '../../types';
+import { logger } from '../../utils/logger';
 
 /**
  * Options for the remark mixins plugin
@@ -119,7 +120,7 @@ export const remarkMixins: Plugin<[RemarkMixinsOptions], Root> = options => {
 
   return (tree: Root) => {
     if (debug) {
-      console.log('[remarkMixins] Processing mixins with options:', {
+      logger.debug('Processing mixins with options:', {
         basePath,
         maxDepth,
         customMixinCount: Object.keys(customMixins).length,
@@ -159,7 +160,7 @@ function processTextNode(node: Text, context: MixinContext) {
   }
 
   if (context.debug) {
-    console.log(`[remarkMixins] Found ${mixinDirectives.length} mixin directives in text node`);
+    logger.debug(`Found ${mixinDirectives.length} mixin directives in text node`);
   }
 
   // Process directives in reverse order to maintain correct positions
@@ -207,7 +208,9 @@ function extractMixinDirectives(text: string): MixinDirective[] {
       try {
         parameters = parseParameters(paramString);
       } catch (error) {
-        console.warn(`[remarkMixins] Failed to parse parameters for mixin "${mixinName}":`, error);
+        logger.warn(
+          `Failed to parse parameters for mixin "${mixinName}": ${error instanceof Error ? error.message : String(error)}`
+        );
       }
     }
 
@@ -271,24 +274,21 @@ function parseParameterValue(value: string): YamlValue {
  */
 function processMixinDirective(directive: MixinDirective, context: MixinContext): string {
   if (context.depth >= context.maxDepth) {
-    console.warn(
-      `[remarkMixins] Maximum recursion depth (${context.maxDepth}) reached for mixin "${directive.name}"`
+    logger.warn(
+      `Maximum recursion depth (${context.maxDepth}) reached for mixin "${directive.name}"`
     );
     return directive.fullMatch; // Return original directive
   }
 
   if (context.debug) {
-    console.log(
-      `[remarkMixins] Processing mixin "${directive.name}" with parameters:`,
-      directive.parameters
-    );
+    logger.debug(`Processing mixin "${directive.name}" with parameters:`, directive.parameters);
   }
 
   // Load mixin content
   const mixinContent = loadMixinContent(directive.name, context);
 
   if (!mixinContent) {
-    console.warn(`[remarkMixins] Mixin "${directive.name}" not found`);
+    logger.warn(`Mixin "${directive.name}" not found`);
     return directive.fullMatch; // Return original directive
   }
 
@@ -335,7 +335,9 @@ function loadMixinContent(mixinName: string, context: MixinContext): string | nu
     }
   } catch (error) {
     if (context.debug) {
-      console.warn(`[remarkMixins] Failed to load mixin file "${filePath}":`, error);
+      logger.warn(
+        `Failed to load mixin file "${filePath}": ${error instanceof Error ? error.message : String(error)}`
+      );
     }
   }
 
@@ -359,13 +361,13 @@ function processTemplateFields(
 
     if (value !== undefined && value !== null) {
       if (debug) {
-        console.log(`[remarkMixins] Replacing template field "${trimmedField}" with value:`, value);
+        logger.debug(`Replacing template field "${trimmedField}" with value:`, value);
       }
       return String(value);
     }
 
     if (debug) {
-      console.log(`[remarkMixins] Template field "${trimmedField}" not found, keeping original`);
+      logger.debug(`Template field "${trimmedField}" not found, keeping original`);
     }
 
     return match; // Keep original if not found

--- a/src/plugins/remark/plugin-order-validator.ts
+++ b/src/plugins/remark/plugin-order-validator.ts
@@ -16,6 +16,7 @@ import type {
   PluginOrderWarning,
   PluginOrderValidationOptions,
 } from './types';
+import { logger } from '../../utils/logger';
 
 /**
  * Validator for plugin execution order
@@ -60,7 +61,7 @@ export class PluginOrderValidator {
     const warnings: PluginOrderWarning[] = [];
 
     if (debug) {
-      console.log('[PluginOrderValidator] Validating plugin order:', pluginNames);
+      logger.debug('Validating plugin order:', pluginNames);
     }
 
     // Build a position map for quick lookups
@@ -86,7 +87,7 @@ export class PluginOrderValidator {
       }
 
       if (debug) {
-        console.log(`[PluginOrderValidator] Checking constraints for ${pluginName}`);
+        logger.debug(`Checking constraints for ${pluginName}`);
       }
 
       // Check runBefore constraints
@@ -162,7 +163,7 @@ export class PluginOrderValidator {
     // Log warnings if requested
     if (logWarnings && warnings.length > 0) {
       for (const warning of warnings) {
-        console.warn(`[PluginOrderValidator] WARNING: ${warning.message}`);
+        logger.warn(warning.message);
       }
     }
 
@@ -174,11 +175,13 @@ export class PluginOrderValidator {
       try {
         suggestedOrder = this.topologicalSort(pluginNames);
         if (debug) {
-          console.log('[PluginOrderValidator] Suggested order:', suggestedOrder);
+          logger.debug('Suggested order:', suggestedOrder);
         }
       } catch (error) {
         if (debug) {
-          console.error('[PluginOrderValidator] Failed to generate suggested order:', error);
+          logger.error(
+            `Failed to generate suggested order: ${error instanceof Error ? error.message : String(error)}`
+          );
         }
       }
     }
@@ -417,7 +420,7 @@ export class PluginOrderValidator {
         for (const cap of metadata.capabilities) {
           providedCapabilities.add(cap);
           if (options.debug) {
-            console.log(`[PluginOrderValidator] Plugin "${pluginName}" provides: ${cap}`);
+            logger.debug(`Plugin "${pluginName}" provides: ${cap}`);
           }
         }
       }

--- a/src/plugins/remark/signature-lines.ts
+++ b/src/plugins/remark/signature-lines.ts
@@ -15,6 +15,7 @@
 import { visit } from 'unist-util-visit';
 import type { Plugin } from 'unified';
 import type { Root, Text, HTML } from 'mdast';
+import { logger } from '../../utils/logger';
 
 /**
  * Options for the signature lines plugin
@@ -72,9 +73,7 @@ function sanitizeCssClassName(className: string): string {
   const validPattern = /^[a-zA-Z_][\w-]*$/;
 
   if (!className || !validPattern.test(className)) {
-    console.warn(
-      `[signature-lines] Invalid CSS class name "${className}", using default "signature-line"`
-    );
+    logger.warn(`Invalid CSS class name "${className}", using default "signature-line"`);
     return 'signature-line';
   }
 
@@ -108,7 +107,7 @@ const remarkSignatureLines: Plugin<[SignatureLinesOptions?], Root> = (options = 
 
   return (tree: Root) => {
     if (config.debug) {
-      console.log('[signature-lines] Processing tree...');
+      logger.debug('Processing tree...');
     }
 
     visit(tree, 'text', (node: Text, index, parent) => {
@@ -125,7 +124,7 @@ const remarkSignatureLines: Plugin<[SignatureLinesOptions?], Root> = (options = 
       }
 
       if (config.debug) {
-        console.log('[signature-lines] Found signature line in text:', text);
+        logger.debug('Found signature line in text:', text);
       }
 
       // If we're not adding CSS classes, leave the text as-is
@@ -136,7 +135,7 @@ const remarkSignatureLines: Plugin<[SignatureLinesOptions?], Root> = (options = 
       // Process the text and wrap signature lines in HTML spans
       const processedText = text.replace(underscorePattern, match => {
         if (config.debug) {
-          console.log(`[signature-lines] Wrapping ${match.length} underscores`);
+          logger.debug(`Wrapping ${match.length} underscores`);
         }
         return `<span class="${safeCssClassName}">${match}</span>`;
       });
@@ -152,7 +151,7 @@ const remarkSignatureLines: Plugin<[SignatureLinesOptions?], Root> = (options = 
     });
 
     if (config.debug) {
-      console.log('[signature-lines] Processing complete');
+      logger.debug('Processing complete');
     }
   };
 };

--- a/src/plugins/remark/template-fields.ts
+++ b/src/plugins/remark/template-fields.ts
@@ -47,6 +47,7 @@
 import { visit } from 'unist-util-visit';
 import type { Plugin } from 'unified';
 import type { Root } from 'mdast';
+import { logger } from '../../utils/logger';
 import { fieldTracker } from '../../extensions/tracking/field-tracker';
 import { fieldSpan } from '../../extensions/tracking/field-span';
 import { extensionHelpers as helpers } from '../../extensions/helpers/index';
@@ -282,7 +283,10 @@ function resolveFieldValue(
           mixinType: 'helper',
         };
       } catch (error) {
-        console.warn(`Error calling Handlebars helper '${helperName}':`, error);
+        logger.warn(
+          `Error calling Handlebars helper '${helperName}':`,
+          error instanceof Error ? error.message : String(error)
+        );
         return {
           value: undefined,
           hasLogic: true,
@@ -317,7 +321,10 @@ function resolveFieldValue(
           mixinType: 'helper',
         };
       } catch (error) {
-        console.warn(`Error calling helper '${helperName}':`, error);
+        logger.warn(
+          `Error calling helper '${helperName}':`,
+          error instanceof Error ? error.message : String(error)
+        );
         return {
           value: undefined,
           hasLogic: true,
@@ -758,7 +765,10 @@ function parseHelperArguments(
           args.push(nestedResult);
           continue;
         } catch (error) {
-          console.warn(`Error calling nested helper '${helperName}':`, error);
+          logger.warn(
+            `Error calling nested helper '${helperName}':`,
+            error instanceof Error ? error.message : String(error)
+          );
           // Fall through to treat as metadata reference
         }
       }
@@ -897,7 +907,10 @@ function parseHandlebarsArguments(
             args.push(nestedResult);
             continue;
           } catch (error) {
-            console.warn(`Error calling Handlebars subexpression helper '${helperName}':`, error);
+            logger.warn(
+              `Error calling Handlebars subexpression helper '${helperName}':`,
+              error instanceof Error ? error.message : String(error)
+            );
             args.push(undefined);
             continue;
           }
@@ -1096,8 +1109,8 @@ function processTemplateFieldsInAST(
         const hasUnresolvedFields = /\{\{[^}]+\}\}/.test(workingValue);
         if (!hasUnresolvedFields) {
           if (debug) {
-            console.log(
-              `⏭️ Skipping HTML node with existing field spans: "${workingValue.substring(0, 100)}..."`
+            logger.debug(
+              `Skipping HTML node with existing field spans: "${workingValue.substring(0, 100)}..."`
             );
           }
           return;
@@ -1107,7 +1120,7 @@ function processTemplateFieldsInAST(
       // Skip processing if this text node is inside existing field tracking spans
       if (node.type === 'text' && isInsideFieldTrackingSpan(node, parent)) {
         if (debug) {
-          console.log(`⏭️ Skipping text node inside existing field spans: "${originalValue}"`);
+          logger.debug(`Skipping text node inside existing field spans: "${originalValue}"`);
         }
         return;
       }
@@ -1129,8 +1142,8 @@ function processTemplateFieldsInAST(
       }
 
       if (debug) {
-        console.log(
-          `📋 Found ${templateFields.length} template fields in ${node.type}: "${normalizedValue}"`
+        logger.debug(
+          `Found ${templateFields.length} template fields in ${node.type}: "${normalizedValue}"`
         );
       }
 
@@ -1172,8 +1185,8 @@ function processTemplateFieldsInAST(
           processedText.substring(field.endIndex);
 
         if (debug) {
-          console.log(
-            `🔄 Replaced ${field.pattern} with "${formattedValue}" (original: ${originalPattern})`
+          logger.debug(
+            `Replaced ${field.pattern} with "${formattedValue}" (original: ${originalPattern})`
           );
         }
       }
@@ -1210,13 +1223,13 @@ const remarkTemplateFields: Plugin<[TemplateFieldOptions], Root> = options => {
 
   return (tree: Root) => {
     if (debug) {
-      console.log('📝 Processing template fields with remark plugin');
-      console.log('📊 Metadata:', metadata);
-      console.log('📋 Field patterns:', fieldPatterns);
+      logger.debug('Processing template fields with remark plugin');
+      logger.debug('Metadata:', metadata);
+      logger.debug('Field patterns:', fieldPatterns);
       if (enableFieldTracking) {
-        console.log('🎯 Field tracking highlighting enabled');
+        logger.debug('Field tracking highlighting enabled');
       }
-      console.log('🔧 Code block processing enabled by default');
+      logger.debug('Code block processing enabled by default');
     }
 
     // Process all template fields in the AST with optional field tracking
@@ -1230,7 +1243,7 @@ const remarkTemplateFields: Plugin<[TemplateFieldOptions], Root> = options => {
     );
 
     if (debug) {
-      console.log('✅ Template field processing completed');
+      logger.debug('Template field processing completed');
     }
   };
 };

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -53,8 +53,20 @@ let debugEnabled = false;
 
 let logLevel: 'debug' | 'info' | 'warn' | 'error' | 'none' = getConfig().logging.level;
 
+function safeSerialize(data: unknown): string {
+  try {
+    return JSON.stringify(data);
+  } catch {
+    try {
+      return String(data);
+    } catch {
+      return '[Unserializable data]';
+    }
+  }
+}
+
 function writeToStderr(prefix: string, message: string, data?: unknown): void {
-  const dataPart = data !== undefined ? ` ${JSON.stringify(data)}` : '';
+  const dataPart = data !== undefined ? ` ${safeSerialize(data)}` : '';
   process.stderr.write(`${prefix} ${message}${dataPart}\n`);
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -9,7 +9,7 @@
  * - Multiple log levels (debug, info, warn, error)
  * - Debug mode controlled by environment variable
  * - Structured logging with contextual data
- * - Console-based output with formatted prefixes
+ * - stderr output via process.stderr.write (debug/info) and console.warn/error (warn/error)
  * - Optional data parameter for detailed logging
  * - Lightweight with no external dependencies
  *
@@ -53,6 +53,11 @@ let debugEnabled = false;
 
 let logLevel: 'debug' | 'info' | 'warn' | 'error' | 'none' = getConfig().logging.level;
 
+function writeToStderr(prefix: string, message: string, data?: unknown): void {
+  const dataPart = data !== undefined ? ` ${JSON.stringify(data)}` : '';
+  process.stderr.write(`${prefix} ${message}${dataPart}\n`);
+}
+
 export const logger = {
   /**
    * Enable or disable debug logging
@@ -87,7 +92,7 @@ export const logger = {
   debug: (message: string, data?: unknown) => {
     const isDebugEnabled = debugEnabled || getConfig().logging.debug;
     if (isDebugEnabled) {
-      console.debug(`[DEBUG] ${message}`, data || '');
+      writeToStderr('[DEBUG]', message, data);
     }
   },
 
@@ -106,7 +111,7 @@ export const logger = {
    */
   info: (message: string, data?: unknown) => {
     if (logLevel === 'none' || logLevel === 'warn' || logLevel === 'error') return;
-    console.info(`[INFO] ${message}`, data || '');
+    writeToStderr('[INFO]', message, data);
   },
 
   /**

--- a/tests/e2e/cli-params.e2e.test.ts
+++ b/tests/e2e/cli-params.e2e.test.ts
@@ -238,11 +238,11 @@ describe('file -> output file', () => {
 describe('--debug', () => {
   for (const target of TARGETS) {
     it(`[${target.name}] shows Metadata: block in output`, async () => {
-      const { stdout, exitCode } = await target.run(
+      const { stderr, exitCode } = await target.run(
         `--debug "${path.join(FIXTURES, 'minimal.md')}"`
       );
       expect(exitCode).toBe(0);
-      expect(stdout).toContain('Metadata:');
+      expect(stderr).toContain('Metadata:');
     });
   }
 });
@@ -878,12 +878,12 @@ describe('Combinations', () => {
       const metaDir = path.join(tmpDir, `${target.name}-combo`);
       fs.mkdirSync(metaDir);
       const out = path.join(metaDir, 'out.md');
-      const { stdout, exitCode } = await target.run(
+      const { stderr, exitCode } = await target.run(
         `--debug --export-json --output-path "${metaDir}" "${path.join(FIXTURES, 'full.md')}" "${out}"`
       );
       expect(exitCode).toBe(0);
-      expect(stdout).toContain('Metadata:');
-      expect(stdout).toContain('Exported files:');
+      expect(stderr).toContain('Metadata:');
+      expect(stderr).toContain('Exported files:');
       expect(fs.existsSync(path.join(metaDir, 'metadata.json'))).toBe(true);
     });
 

--- a/tests/e2e/cli.e2e.test.ts
+++ b/tests/e2e/cli.e2e.test.ts
@@ -65,7 +65,7 @@ This is test content.`;
       fs.writeFileSync(inputPath, inputContent);
 
       try {
-        const { stdout } = await execAsync(`node "${cliPath}" "${inputPath}" "${outputPath}"`);
+        const { stderr } = await execAsync(`node "${cliPath}" "${inputPath}" "${outputPath}"`);
 
         expect(fs.existsSync(outputPath)).toBe(true);
 
@@ -73,7 +73,7 @@ This is test content.`;
         expect(outputContent).toContain('Article 1. First Section');
         expect(outputContent).toContain('  Section 1. Subsection');
         expect(outputContent).toContain('This is test content.');
-        expect(stdout).toContain('Successfully processed');
+        expect(stderr).toContain('Successfully processed');
       } catch (error: any) {
         console.error('CLI Error:', error.stderr);
         throw new Error(`CLI command failed: ${error.message}`);
@@ -129,12 +129,12 @@ Debug content.`;
 
       fs.writeFileSync(inputPath, inputContent);
 
-      const { stdout } = await execAsync(`node ${cliPath} --debug "${inputPath}" "${outputPath}"`);
+      const { stderr } = await execAsync(`node ${cliPath} --debug "${inputPath}" "${outputPath}"`);
 
-      expect(stdout).toContain('Metadata:');
-      expect(stdout).toContain('"title": "Debug Test"');
-      expect(stdout).toContain('"author": "Test Author"');
-      expect(stdout).toContain('"debug_field": "debug_value"');
+      expect(stderr).toContain('Metadata:');
+      expect(stderr).toContain('"title": "Debug Test"');
+      expect(stderr).toContain('"author": "Test Author"');
+      expect(stderr).toContain('"debug_field": "debug_value"');
     });
 
     it('should show exported files in debug mode', async () => {
@@ -150,12 +150,12 @@ Content with metadata export.`;
 
       fs.writeFileSync(inputPath, inputContent);
 
-      const { stdout } = await execAsync(
+      const { stderr } = await execAsync(
         `node ${cliPath} --debug --export-json --output-path "${testDir}" "${inputPath}" "${outputPath}"`
       );
 
-      expect(stdout).toContain('Exported files:');
-      expect(stdout).toContain('debug-metadata.json');
+      expect(stderr).toContain('Exported files:');
+      expect(stderr).toContain('debug-metadata.json');
     });
   });
 
@@ -345,14 +345,14 @@ Reference: |reference_value|`;
 
       fs.writeFileSync(inputPath, inputContent);
 
-      const { stdout } = await execAsync(
+      const { stderr } = await execAsync(
         `node ${cliPath} --debug --export-json --output-path "${testDir}" "${inputPath}" "${outputPath}"`
       );
 
       expect(fs.existsSync(outputPath)).toBe(true);
       expect(fs.existsSync(path.join(testDir, 'metadata.json'))).toBe(true);
-      expect(stdout).toContain('Metadata:');
-      expect(stdout).toContain('Exported files:');
+      expect(stderr).toContain('Metadata:');
+      expect(stderr).toContain('Exported files:');
 
       const outputContent = fs.readFileSync(outputPath, 'utf8');
       expect(outputContent).toContain('Article 1. Main Section');

--- a/tests/integration/cli-html-no-indent.integration.test.ts
+++ b/tests/integration/cli-html-no-indent.integration.test.ts
@@ -87,7 +87,7 @@ Final content.`;
             return;
           }
 
-          expect(stdout).toContain('Files generated successfully!');
+          expect(stderr).toContain('Files generated successfully!');
 
           // Check that HTML file was generated
           const htmlPath = path.join(testOutputDir, 'test-headers.html');
@@ -160,7 +160,7 @@ Final content.`;
             return;
           }
 
-          expect(stdout).toContain('Files generated successfully!');
+          expect(stderr).toContain('Files generated successfully!');
 
           // Check that PDF file was generated
           const pdfPath = path.join(testOutputDir, 'test-headers.pdf');

--- a/tests/integration/stdout-clean.integration.test.ts
+++ b/tests/integration/stdout-clean.integration.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview Smoke test: processing pipeline must not write to stdout.
+ *
+ * All diagnostic output (debug, info, warn, error) must go to stderr.
+ * stdout is reserved for intentional program output.
+ */
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import { processLegalMarkdown } from '../../src/extensions/remark/legal-markdown-processor';
+
+describe('stdout cleanliness', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not write to stdout during processing with debug:false', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await processLegalMarkdown('# Hello\n\n{{name}} was here.', {
+      additionalMetadata: { name: 'World' },
+      debug: false,
+    });
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not write to stdout during processing with debug:true', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await processLegalMarkdown('# Hello\n\n{{name}} was here.', {
+      additionalMetadata: { name: 'World' },
+      debug: true,
+    });
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/cli/service-pdf-dependency.unit.test.ts
+++ b/tests/unit/cli/service-pdf-dependency.unit.test.ts
@@ -22,7 +22,7 @@ describe('CliService PDF dependency handling', () => {
 
   it('prints friendly install instructions for PdfDependencyError', () => {
     const service = new CliService({});
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
     (service as any).handleError(new PdfDependencyError());
 

--- a/tests/unit/core/utils/frontmatter-merger.unit.test.ts
+++ b/tests/unit/core/utils/frontmatter-merger.unit.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { vi } from 'vitest';
+import { logger } from '../../../../src/utils/logger';
 
 // Import fail function from vitest
 const fail = (message: string) => {
@@ -151,7 +152,7 @@ describe('Frontmatter Merger', () => {
     });
 
     it('should validate types when enabled', () => {
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const loggerSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
 
       const current = {
         count: 42,
@@ -163,7 +164,7 @@ describe('Frontmatter Merger', () => {
         config: 'not an object' // Type conflict: object vs string
       };
 
-      const result = mergeFlattened(current, imported, { 
+      const result = mergeFlattened(current, imported, {
         validateTypes: true,
         logOperations: true
       });
@@ -173,14 +174,14 @@ describe('Frontmatter Merger', () => {
         config: { debug: true }       // Current value preserved
       });
 
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(loggerSpy).toHaveBeenCalledWith(
         expect.stringContaining("Type conflict for 'count'")
       );
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(loggerSpy).toHaveBeenCalledWith(
         expect.stringContaining("Type conflict for 'config'")
       );
 
-      consoleSpy.mockRestore();
+      loggerSpy.mockRestore();
     });
 
     it('should handle arrays as atomic values', () => {
@@ -204,24 +205,24 @@ describe('Frontmatter Merger', () => {
     });
 
     it('should log operations when enabled', () => {
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const loggerSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 
       const current = { title: 'Current' };
       const imported = { title: 'Imported', author: 'John' };
 
       mergeFlattened(current, imported, { logOperations: true });
 
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(loggerSpy).toHaveBeenCalledWith(
         expect.stringContaining('Merging frontmatter')
       );
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(loggerSpy).toHaveBeenCalledWith(
         expect.stringContaining("Conflict for 'title': current value kept")
       );
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(loggerSpy).toHaveBeenCalledWith(
         expect.stringContaining("Added 'author' from import")
       );
 
-      consoleSpy.mockRestore();
+      loggerSpy.mockRestore();
     });
   });
 
@@ -367,7 +368,7 @@ describe('Frontmatter Merger', () => {
     });
 
     it('should log sequential operations when enabled', () => {
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const loggerSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 
       const initial = { title: 'Main' };
       const imports = [
@@ -377,14 +378,14 @@ describe('Frontmatter Merger', () => {
 
       mergeSequentially(initial, imports, { logOperations: true });
 
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(loggerSpy).toHaveBeenCalledWith(
         expect.stringContaining('Merged import 1/2: +1 properties')
       );
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(loggerSpy).toHaveBeenCalledWith(
         expect.stringContaining('Merged import 2/2: +1 properties')
       );
 
-      consoleSpy.mockRestore();
+      loggerSpy.mockRestore();
     });
   });
 

--- a/tests/unit/core/utils/reserved-fields-filter.unit.test.ts
+++ b/tests/unit/core/utils/reserved-fields-filter.unit.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { vi } from 'vitest';
+import { logger } from '../../../../src/utils/logger';
 import {
   filterReservedFields,
   isReservedField,
@@ -137,8 +138,8 @@ describe('Reserved Fields Filter', () => {
     });
 
     it('should support logging of filtered fields', () => {
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      
+      const loggerSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
       const input = {
         'level-one': 'ARTICLE %n.',
         'force_commands': '--pdf',
@@ -147,11 +148,11 @@ describe('Reserved Fields Filter', () => {
 
       filterReservedFields(input, { logFiltered: true });
 
-      expect(consoleSpy).toHaveBeenCalledWith("Reserved field 'level-one' ignored from import");
-      expect(consoleSpy).toHaveBeenCalledWith("Reserved field 'force_commands' ignored from import");
-      expect(consoleSpy).toHaveBeenCalledTimes(2);
+      expect(loggerSpy).toHaveBeenCalledWith("Reserved field 'level-one' ignored from import");
+      expect(loggerSpy).toHaveBeenCalledWith("Reserved field 'force_commands' ignored from import");
+      expect(loggerSpy).toHaveBeenCalledTimes(2);
 
-      consoleSpy.mockRestore();
+      loggerSpy.mockRestore();
     });
 
     it('should handle additional reserved fields', () => {

--- a/tests/unit/core/utils/timeout-safety.unit.test.ts
+++ b/tests/unit/core/utils/timeout-safety.unit.test.ts
@@ -8,6 +8,7 @@
 import { flattenObject } from '../../../../src/core/utils/object-flattener';
 import { mergeFlattened } from '../../../../src/core/utils/frontmatter-merger';
 import { vi } from 'vitest';
+import { logger } from '../../../../src/utils/logger';
 
 describe('Timeout Safety Tests', () => {
   describe('Object Flattener Timeout', () => {
@@ -35,23 +36,23 @@ describe('Timeout Safety Tests', () => {
     });
 
     it('should handle circular references with warning', () => {
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      
+      const loggerSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
       const circular: any = { name: 'test' };
       circular.self = circular;
 
       const result = flattenObject(circular);
-      
+
       expect(result).toEqual({
         name: 'test',
         self: '[Circular Reference]'
       });
-      
-      expect(consoleSpy).toHaveBeenCalledWith(
+
+      expect(loggerSpy).toHaveBeenCalledWith(
         expect.stringContaining("Circular reference detected at path 'self'")
       );
 
-      consoleSpy.mockRestore();
+      loggerSpy.mockRestore();
     });
 
     it('should complete normal operations within timeout', () => {

--- a/tests/unit/plugins/remark/clauses.unit.test.ts
+++ b/tests/unit/plugins/remark/clauses.unit.test.ts
@@ -9,6 +9,7 @@ import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkStringify from 'remark-stringify';
 import { remarkClauses, RemarkClausesOptions } from '../../../../src/plugins/remark/clauses';
+import { logger } from '../../../../src/utils/logger';
 
 /**
  * Helper function to process markdown with clauses plugin
@@ -588,13 +589,12 @@ describe('remarkClauses Plugin', () => {
         metadata: {},
       };
 
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const consoleSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
 
       const result = await processMarkdownWithClauses(input, options);
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Unsafe condition'),
-        expect.stringContaining("eval('1+1')")
+        expect.stringContaining('Unsafe condition')
       );
 
       // Should not include the content due to safety rejection
@@ -676,12 +676,12 @@ describe('remarkClauses Plugin', () => {
         debug: true,
       };
 
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 
       await processMarkdownWithClauses(input, options);
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[remarkClauses] Processing clauses with metadata:'),
+        expect.stringContaining('Processing clauses with metadata:'),
         expect.any(Array)
       );
 
@@ -695,12 +695,12 @@ describe('remarkClauses Plugin', () => {
         debug: true,
       };
 
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 
       await processMarkdownWithClauses(input, options);
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[remarkClauses] Condition'),
+        expect.stringContaining('Condition'),
         expect.anything()
       );
 
@@ -714,7 +714,7 @@ describe('remarkClauses Plugin', () => {
         debug: false,
       };
 
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 
       await processMarkdownWithClauses(input, options);
 

--- a/tests/unit/plugins/remark/debug-ast.test.ts
+++ b/tests/unit/plugins/remark/debug-ast.test.ts
@@ -11,15 +11,15 @@ import remarkParse from 'remark-parse';
 import { remarkDebugAST } from '../../../../src/plugins/remark/debug-ast';
 
 describe('Debug AST Plugin', () => {
-  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    // Spy on console.log to capture debug output
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    // Spy on process.stderr.write to capture debug output
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
-    consoleSpy.mockRestore();
+    stderrSpy.mockRestore();
   });
 
   // ==========================================================================
@@ -35,7 +35,7 @@ describe('Debug AST Plugin', () => {
       const tree = processor.parse('# Test');
       await processor.run(tree);
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(stderrSpy).toHaveBeenCalled();
     });
 
     it('should log AST debug header', async () => {
@@ -46,7 +46,7 @@ describe('Debug AST Plugin', () => {
       const tree = processor.parse('Test content');
       await processor.run(tree);
 
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('=== AST DEBUG ==='));
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('=== AST DEBUG ==='));
     });
 
     it('should log total node count', async () => {
@@ -57,7 +57,7 @@ describe('Debug AST Plugin', () => {
       const tree = processor.parse('Test content');
       await processor.run(tree);
 
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Total nodes visited:'));
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Total nodes visited:'));
     });
 
     it('should log debug footer', async () => {
@@ -68,7 +68,7 @@ describe('Debug AST Plugin', () => {
       const tree = processor.parse('Test content');
       await processor.run(tree);
 
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('=== END AST DEBUG ==='));
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('=== END AST DEBUG ==='));
     });
   });
 
@@ -85,7 +85,7 @@ describe('Debug AST Plugin', () => {
       const tree = processor.parse('{{#items}}content{{/items}}');
       await processor.run(tree);
 
-      const calls = consoleSpy.mock.calls.flat().join(' ');
+      const calls = stderrSpy.mock.calls.flat().join(' ');
       expect(calls).toContain('{{#');
     });
 
@@ -97,7 +97,7 @@ describe('Debug AST Plugin', () => {
       const tree = processor.parse('{{#items}}content{{/items}}');
       await processor.run(tree);
 
-      const calls = consoleSpy.mock.calls.flat().join(' ');
+      const calls = stderrSpy.mock.calls.flat().join(' ');
       expect(calls).toContain('{{/');
     });
 
@@ -110,7 +110,7 @@ describe('Debug AST Plugin', () => {
       await processor.run(tree);
 
       // Should log node type
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringMatching(/Node #\d+/));
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringMatching(/Node #\d+/));
     });
 
     it('should ignore simple template fields without # or /', async () => {
@@ -122,7 +122,7 @@ describe('Debug AST Plugin', () => {
       await processor.run(tree);
 
       // Should not log details for simple fields (no {{# or {{/)
-      const calls = consoleSpy.mock.calls.flat();
+      const calls = stderrSpy.mock.calls.flat();
       const hasNodeDetails = calls.some(call =>
         typeof call === 'string' && call.includes('Node #') && call.includes('{{name}}')
       );
@@ -143,7 +143,7 @@ describe('Debug AST Plugin', () => {
       const tree = processor.parse('{{#items}}text{{/items}}');
       await processor.run(tree);
 
-      const calls = consoleSpy.mock.calls.flat().join(' ');
+      const calls = stderrSpy.mock.calls.flat().join(' ');
       expect(calls).toMatch(/\(text\)/);
     });
 
@@ -163,7 +163,7 @@ Paragraph with content.
       await processor.run(tree);
 
       // Should have visited multiple nodes
-      const calls = consoleSpy.mock.calls.flat();
+      const calls = stderrSpy.mock.calls.flat();
       const nodeCountCall = calls.find(call =>
         typeof call === 'string' && call.includes('Total nodes visited:')
       );
@@ -197,9 +197,9 @@ Paragraph with content.
       const tree = processor.parse(markdown);
       await processor.run(tree);
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(stderrSpy).toHaveBeenCalled();
 
-      const calls = consoleSpy.mock.calls.flat().join(' ');
+      const calls = stderrSpy.mock.calls.flat().join(' ');
       expect(calls).toContain('{{#');
       expect(calls).toContain('{{/');
     });
@@ -220,7 +220,7 @@ Content
       const tree = processor.parse(markdown);
       await processor.run(tree);
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(stderrSpy).toHaveBeenCalled();
     });
 
     it('should handle mixed content', async () => {
@@ -243,7 +243,7 @@ Another paragraph with {{variable}}.
       const tree = processor.parse(markdown);
       await processor.run(tree);
 
-      const calls = consoleSpy.mock.calls.flat();
+      const calls = stderrSpy.mock.calls.flat();
       const totalNodesCall = calls.find(call =>
         typeof call === 'string' && call.includes('Total nodes visited:')
       );
@@ -264,8 +264,8 @@ Another paragraph with {{variable}}.
       const tree = processor.parse('');
       await processor.run(tree);
 
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('=== AST DEBUG ==='));
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Total nodes visited:'));
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('=== AST DEBUG ==='));
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Total nodes visited:'));
     });
 
     it('should handle document with only whitespace', async () => {
@@ -276,7 +276,7 @@ Another paragraph with {{variable}}.
       const tree = processor.parse('   \n\n   ');
       await processor.run(tree);
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(stderrSpy).toHaveBeenCalled();
     });
 
     it('should handle very long values', async () => {
@@ -288,9 +288,9 @@ Another paragraph with {{variable}}.
       const tree = processor.parse(`{{#items}}${longContent}{{/items}}`);
       await processor.run(tree);
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(stderrSpy).toHaveBeenCalled();
 
-      const calls = consoleSpy.mock.calls.flat();
+      const calls = stderrSpy.mock.calls.flat();
       const lengthCall = calls.find(call =>
         typeof call === 'string' && call.includes('Full value length:')
       );
@@ -305,7 +305,7 @@ Another paragraph with {{variable}}.
       const tree = processor.parse('{{#items}}Content with émojis 🎉{{/items}}');
       await processor.run(tree);
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(stderrSpy).toHaveBeenCalled();
     });
   });
 
@@ -322,8 +322,8 @@ Another paragraph with {{variable}}.
       const tree = processor.parse('{{#items}}test{{/items}}');
       await processor.run(tree);
 
-      // Just verify console was called - exact format may vary
-      expect(consoleSpy).toHaveBeenCalled();
+      // Just verify stderr was written - exact format may vary
+      expect(stderrSpy).toHaveBeenCalled();
     });
 
     it('should log value in JSON format', async () => {
@@ -334,8 +334,8 @@ Another paragraph with {{variable}}.
       const tree = processor.parse('{{#items}}test{{/items}}');
       await processor.run(tree);
 
-      // Just verify console was called - exact format may vary
-      expect(consoleSpy).toHaveBeenCalled();
+      // Just verify stderr was written - exact format may vary
+      expect(stderrSpy).toHaveBeenCalled();
     });
 
     it('should log full value length', async () => {
@@ -346,8 +346,8 @@ Another paragraph with {{variable}}.
       const tree = processor.parse('{{#items}}test{{/items}}');
       await processor.run(tree);
 
-      // Just verify console was called - exact format may vary
-      expect(consoleSpy).toHaveBeenCalled();
+      // Just verify stderr was written - exact format may vary
+      expect(stderrSpy).toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/plugins/remark/headers.unit.test.ts
+++ b/tests/unit/plugins/remark/headers.unit.test.ts
@@ -11,6 +11,7 @@ import remarkParse from 'remark-parse';
 import remarkStringify from 'remark-stringify';
 import { remarkHeaders, RemarkHeadersOptions } from '../../../../src/plugins/remark/headers';
 import { remarkLegalHeadersParser } from '../../../../src/plugins/remark/legal-headers-parser';
+import { logger } from '../../../../src/utils/logger';
 
 /**
  * Helper function to process markdown with headers plugin
@@ -374,17 +375,17 @@ describe('remarkHeaders Plugin', () => {
         debug: true,
       };
 
-      // Capture console.log calls
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      // Capture logger.debug calls
+      const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 
       await processMarkdownWithHeaders(input, options);
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[remarkHeaders] Processing headers'),
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Processing headers'),
         expect.any(Object)
       );
 
-      consoleSpy.mockRestore();
+      debugSpy.mockRestore();
     });
 
     it('should not produce debug output when disabled', async () => {
@@ -396,13 +397,13 @@ describe('remarkHeaders Plugin', () => {
         debug: false,
       };
 
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 
       await processMarkdownWithHeaders(input, options);
 
-      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(debugSpy).not.toHaveBeenCalled();
 
-      consoleSpy.mockRestore();
+      debugSpy.mockRestore();
     });
   });
 

--- a/tests/unit/plugins/remark/template-fields.test.ts
+++ b/tests/unit/plugins/remark/template-fields.test.ts
@@ -30,6 +30,7 @@ import remarkStringify from 'remark-stringify';
 import remarkTemplateFields from '../../../../src/plugins/remark/template-fields';
 import type { TemplateFieldOptions } from '../../../../src/plugins/remark/template-fields';
 import { fieldTracker } from '../../../../src/extensions/tracking/field-tracker';
+import { logger } from '../../../../src/utils/logger';
 
 describe('Template Fields Plugin', () => {
   beforeEach(() => {
@@ -1391,7 +1392,7 @@ Other
 
   describe('Debug Mode', () => {
     it('should log debug information when enabled', async () => {
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 
       const processor = unified()
         .use(remarkParse)
@@ -1403,16 +1404,16 @@ Other
 
       await processor.process('{{name}}');
 
-      expect(consoleSpy).toHaveBeenCalled();
-      expect(consoleSpy.mock.calls.some(call =>
+      expect(debugSpy).toHaveBeenCalled();
+      expect(debugSpy.mock.calls.some(call =>
         call[0]?.includes('Processing template fields')
       )).toBe(true);
 
-      consoleSpy.mockRestore();
+      debugSpy.mockRestore();
     });
 
     it('should not log when debug disabled', async () => {
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
 
       const processor = unified()
         .use(remarkParse)
@@ -1424,9 +1425,19 @@ Other
 
       await processor.process('{{name}}');
 
-      expect(consoleSpy).not.toHaveBeenCalled();
+      // The plugin itself should not log; other modules (e.g. field-tracker) may call logger.debug
+      const pluginDebugCalls = debugSpy.mock.calls.filter(call =>
+        typeof call[0] === 'string' && (
+          call[0].includes('Processing template fields') ||
+          call[0].includes('template field') ||
+          call[0].includes('Replaced') ||
+          call[0].includes('Found') ||
+          call[0].includes('Skipping')
+        )
+      );
+      expect(pluginDebugCalls).toHaveLength(0);
 
-      consoleSpy.mockRestore();
+      debugSpy.mockRestore();
     });
   });
 });

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -1,0 +1,73 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { logger } from '../../../src/utils/logger';
+
+describe('logger', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    logger.setDebugEnabled(false);
+    logger.setLogLevel('debug');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('debug', () => {
+    it('writes to stderr (not stdout) when debug enabled', () => {
+      logger.setDebugEnabled(true);
+      logger.debug('test message');
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('[DEBUG] test message'));
+      expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('[DEBUG]'));
+    });
+
+    it('includes data in output', () => {
+      logger.setDebugEnabled(true);
+      logger.debug('with data', { key: 'value' });
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('[DEBUG] with data'));
+    });
+
+    it('does not write when debug disabled', () => {
+      logger.setDebugEnabled(false);
+      logger.debug('silent');
+      const allCalls = stderrSpy.mock.calls.map(c => c[0]);
+      expect(allCalls.join('')).not.toContain('[DEBUG]');
+    });
+  });
+
+  describe('info', () => {
+    it('writes to stderr (not stdout)', () => {
+      logger.info('info message');
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('[INFO] info message'));
+      expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('[INFO]'));
+    });
+
+    it('is suppressed by logLevel warn', () => {
+      logger.setLogLevel('warn');
+      logger.info('suppressed');
+      const allCalls = stderrSpy.mock.calls.map(c => c[0]);
+      expect(allCalls.join('')).not.toContain('[INFO]');
+    });
+  });
+
+  describe('warn', () => {
+    it('delegates to console.warn', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      logger.warn('warn message');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[WARN] warn message'), '');
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('error', () => {
+    it('delegates to console.error', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      logger.error('error message');
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('[ERROR] error message'), '');
+      errorSpy.mockRestore();
+    });
+  });
+});

--- a/tests/unit/utils/plugin-order-validator.unit.test.ts
+++ b/tests/unit/utils/plugin-order-validator.unit.test.ts
@@ -13,16 +13,17 @@ import {
   createPluginRegistry,
 } from '../../../src/plugins/remark/plugin-order-validator';
 import type { PluginMetadata } from '../../../src/plugins/remark/types';
+import { logger } from '../../../src/utils/logger';
 
 describe('PluginOrderValidator', () => {
-  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+  let loggerWarnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    loggerWarnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    consoleWarnSpy.mockRestore();
+    loggerWarnSpy.mockRestore();
   });
 
   describe('Correct Plugin Order', () => {
@@ -532,8 +533,8 @@ describe('PluginOrderValidator', () => {
 
       validator.validate([], { throwOnError: false, logWarnings: true });
 
-      expect(consoleWarnSpy).toHaveBeenCalled();
-      expect(consoleWarnSpy.mock.calls[0][0]).toContain('requiredPlugin');
+      expect(loggerWarnSpy).toHaveBeenCalled();
+      expect(loggerWarnSpy.mock.calls[0][0]).toContain('requiredPlugin');
     });
 
     it('should not log warnings when logWarnings is false', () => {
@@ -550,7 +551,7 @@ describe('PluginOrderValidator', () => {
 
       validator.validate([], { throwOnError: false, logWarnings: false });
 
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
+      expect(loggerWarnSpy).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

- `logger.ts`: `info` and `debug` levels now write to `process.stderr.write` instead of `console.info`/`console.debug` (which route to stdout)
- All `console.log` calls in the processing pipeline (25 files across `src/plugins/remark/`, `src/core/`, `src/extensions/`) replaced with `logger.debug`
- CLI service progress messages (`[info]`, `[ok]`, `[warn]`, `[error]`) moved to `console.error` and emoji prefixes removed

stdout is now 100% clean regardless of `--debug` mode, making the CLI safe to pipe and usable in tmux demos without log bleed.

## Test plan

- [x] `tests/unit/utils/logger.test.ts` — verifies debug/info write to stderr, not stdout
- [x] `tests/integration/stdout-clean.integration.test.ts` — smoke test: `processLegalMarkdown()` produces zero stdout writes with both `debug:false` and `debug:true`
- [x] Full suite: 3468 tests passing, 0 failures
- [x] Manual CLI verification: `legal-md -d input.md output.md 2>/dev/null` produces empty stdout